### PR TITLE
Let supervisor run with :logger option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ branches:
   only:
     - master
 
-script: bundle exec rake
+script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.2
+  - 2.0
+  - 2.1
+  - 2.2
 
 branches:
   only:

--- a/lib/serverengine/config_loader.rb
+++ b/lib/serverengine/config_loader.rb
@@ -56,8 +56,8 @@ module ServerEngine
     private
 
     def create_logger
-      if logger = @config[:logger]
-        @logger = logger
+      if @config[:logger].is_a?(DaemonLogger)
+        @logger = @config[:logger]
         return
       end
 

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -22,6 +22,8 @@ module ServerEngine
   class Daemon
     include ConfigLoader
 
+    attr_reader :server
+
     def initialize(server_module, worker_module, load_config_proc={}, &block)
       @server_module = server_module
       @worker_module = worker_module
@@ -157,7 +159,7 @@ module ServerEngine
     private
 
     def create_server(logger)
-      @create_server_proc.call(@load_config_proc, logger)
+      @server = @create_server_proc.call(@load_config_proc, logger)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,7 @@ include ServerEngine
 
 require 'server_worker_context'
 
+RSpec.configure do |c|
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
+end

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -46,7 +46,6 @@ describe ServerEngine::Supervisor do
         sv.logger.should be_an_instance_of(ServerEngine::DaemonLogger)
       ensure
         sv.stop(true)
-        t.kill # temporary
         t.join
       end
     end
@@ -79,7 +78,6 @@ describe ServerEngine::Supervisor do
         sv.logger.should be_an_instance_of(ServerEngine::DaemonLogger)
       ensure
         sv.stop(true)
-        t.kill # temporary
         t.join
       end
     end


### PR DESCRIPTION
Hi, thank you for a nice tool! I like it :heart: 
I found one problem when using [Sneakers](https://github.com/jondot/sneakers) with supervisor.

When Supervisor is given a Logger instance as :logger option, an exception occurs ([detail](https://github.com/nownabe/serverengine-playground/blob/master/debug_20150521/51b60fa_output_3.txt)):

```
Unexpected error comparison of Fixnum with String failed
```
And when Supervisor is given both :logger option and :log option, another exception occurs ([detail](https://github.com/nownabe/serverengine-playground/blob/master/debug_20150521/51b60fa_output_4.rb)):
```
Unexpected error undefined method `logdev=' for #<Logger:0x007fc745189d18>
```

I used [this](https://github.com/nownabe/serverengine-playground/blob/master/debug_20150521/test.rb) check script.

These errors occur because ServerEngine::DaemonLogger has richer methods than Logger and Supervisor use these methods.

In this pull request, if given logger is not a ServerEngine::DaemonLogger, ConfigLoader ignore :logger option.
This is my proposal.

Please check it.