### PR TITLE
Add API for generating path for Socket Manager and use fiddle not ffi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ branches:
     - master
 
 script: bundle exec rake spec
+
+before_install:
+ - gem update bundler

--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -58,6 +58,18 @@ module ServerEngine
     end
 
     class Server
+      def self.generate_path
+        if ServerEngine.windows?
+          for port in 10000..65535
+            if `netstat -na | find "#{port}"`.length == 0
+              return port
+            end
+          end
+        else
+          '/tmp/SERVERENGINE_SOCKETMANAGER_' + Time.now.to_s.gsub(' ', '') + '_' + Process.pid.to_s
+        end
+      end
+
       def self.open(path)
         new(path)
       end

--- a/lib/serverengine/socket_manager_win.rb
+++ b/lib/serverengine/socket_manager_win.rb
@@ -84,6 +84,8 @@ module ServerEngine
       end
 
       def start_server(addr)
+        # TODO: use TCPServer, but this is risky because using not conflict path is easy,
+        # but using not conflict port is difficult. Then We had better implement using NamedPipe.
         @server = TCPServer.new("127.0.0.1", addr)
         @thread = Thread.new do
           begin

--- a/lib/serverengine/socket_manager_win.rb
+++ b/lib/serverengine/socket_manager_win.rb
@@ -24,23 +24,23 @@ module ServerEngine
     module ClientModule
       private
 
-      include WinSock::Constants
-
       def connect_peer(addr)
         return TCPSocket.open("127.0.0.1", addr)
       end
 
       def recv_tcp(peer, sent)
-        proto = WinSock.map_to_proto(sent)
-        sock = WinSock.WSASocketA(AF_INET, SOCK_STREAM, 0, proto, 0, WSA_FLAG_OVERLAPPED)
-        fd = WinSock.rb_w32_wrap_io_handle(sock, 0)
+        proto = WinSock::WSAPROTOCOL_INFO.malloc
+        proto.to_ptr.ref.ptr[0, WinSock::WSAPROTOCOL_INFO.size] = sent
+        sock = WinSock.WSASocketA(Socket::AF_INET, Socket::SOCK_STREAM, 0, proto, 0, 1)
+        fd = WinSockWrapper.rb_w32_wrap_io_handle(sock, 0)
         return TCPServer.for_fd(fd)
       end
 
       def recv_udp(peer, sent)
-        proto = WinSock.map_to_proto(sent)
-        sock = WinSock.WSASocketA(AF_INET, SOCK_DGRAM, 0, proto, 0, WSA_FLAG_OVERLAPPED)
-        fd = WinSock.rb_w32_wrap_io_handle(sock, 0)
+        proto = WinSock::WSAPROTOCOL_INFO.malloc
+        proto.to_ptr.ref.ptr[0, WinSock::WSAPROTOCOL_INFO.size] = sent
+        sock = WinSock.WSASocketA(Socket::AF_INET, Socket::SOCK_DGRAM, 0, proto, 0, 1)
+        fd = WinSockWrapper.rb_w32_wrap_io_handle(sock, 0)
         return UDPSocket.for_fd(fd)
       end
     end
@@ -48,34 +48,29 @@ module ServerEngine
     module ServerModule
       private
 
-      include WinSock::Constants
-
       def listen_tcp_new(bind_ip, port)
         # TODO IPv6 is not supported
-        sock = WinSock.WSASocketA(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, WSA_FLAG_OVERLAPPED)
+        sock = WinSock.WSASocketA(Socket::AF_INET, Socket::SOCK_STREAM, Socket::IPPROTO_TCP, nil, 0, 1)
         sock_addr = pack_sockaddr(bind_ip, port)
-        WinSock.bind(sock, sock_addr, sock_addr.size)
-        WinSock.listen(sock, SOMAXCONN)
+        WinSock.bind(sock, sock_addr, WinSock::SockaddrIn.size)
+        WinSock.listen(sock, Socket::SOMAXCONN)
 
         return sock
       end
 
       def listen_udp_new(bind_ip, port)
         # TODO IPv6 is not supported
-        sock = WinSock.WSASocketA(AF_INET, SOCK_DGRAM, IPPROTO_UDP, nil, 0, WSA_FLAG_OVERLAPPED)
+        sock = WinSock.WSASocketA(Socket::AF_INET, Socket::SOCK_DGRAM, Socket::IPPROTO_UDP, nil, 0, 1)
         sock_addr = pack_sockaddr(bind_ip, port)
-        WinSock.bind(sock, sock_addr, sock_addr.size)
-
+        WinSock.bind(sock, sock_addr, WinSock::SockaddrIn.size)
         return sock
       end
 
       def pack_sockaddr(bind_ip, port)
-        sock_addr = WinSock::SockaddrIn.new
-        in_addr = WinSock::InAddr.new
-        in_addr[:s_addr] = WinSock::inet_addr(bind_ip.to_s)
-        sock_addr[:sin_family] = AF_INET
-        sock_addr[:sin_port] = htons(port)
-        sock_addr[:sin_addr] = in_addr
+        sock_addr = WinSock::SockaddrIn.malloc
+        sock_addr.sin_family = Socket::AF_INET
+        sock_addr.sin_port = htons(port)
+        sock_addr.sin_addr = WinSock.inet_addr(bind_ip.to_s)
         return sock_addr
       end
 
@@ -104,13 +99,13 @@ module ServerEngine
 
       def stop_server
         @tcp_sockets.reject! {|key,lhandle|
-          lfd=WinSock.rb_w32_wrap_io_handle(lhandle, 0)
-          lsock=UDPSocket.for_fd(lfd)
+          lfd=WinSockWrapper.rb_w32_wrap_io_handle(lhandle, 0)
+          lsock=TCPServer.for_fd(lfd)
           lsock.close
           true
         }
         @udp_sockets.reject! {|key,uhandle|
-          ufd=WinSock.rb_w32_wrap_io_handle(uhandle, 0)
+          ufd=WinSockWrapper.rb_w32_wrap_io_handle(uhandle, 0)
           usock=UDPSocket.for_fd(ufd)
           usock.close
           true
@@ -123,21 +118,20 @@ module ServerEngine
         case method
         when :listen_tcp
           sock = listen_tcp(bind, port)
-          type = SOCK_STREAM
+          type = Socket::SOCK_STREAM
         when :listen_udp
           sock = listen_udp(bind, port)
-          type = SOCK_DGRAM
+          type = Socket::SOCK_DGRAM
         else
           raise ArgumentError, "Unknown method: #{method.inspect}"
         end
 
-        proto = WinSock::WSAPROTOCOL_INFO.new
+        proto = WinSock::WSAPROTOCOL_INFO.malloc
         unless WinSock.WSADuplicateSocketA(sock, pid, proto) == 0
           raise "WSADuplicateSocketA faild (0x%x)" % WinSock.WSAGetLastError
         end
-
-        proto_map = WinSock.proto_to_map(proto)
-        SocketManager.send_peer(peer, proto_map)
+        proto_bin = proto.to_ptr.to_s
+        SocketManager.send_peer(peer, proto_bin)
       end
     end
   end

--- a/lib/serverengine/winsock.rb
+++ b/lib/serverengine/winsock.rb
@@ -18,176 +18,62 @@
 module ServerEngine
   module WinSock
 
-    require 'ffi'
-    extend FFI::Library
+    require 'fiddle/import'
+    require 'fiddle/types'
+    require 'socket'
 
-    module Constants
-      include Socket::Constants
+    extend Fiddle::Importer
 
-      # Flags
-      WSA_FLAG_OVERLAPPED = 0x01
-      WSA_FLAG_MULTIPOINT_C_ROOT = 0x02
-      WSA_FLAG_MULTIPOINT_C_LEAF = 0x04
-      WSA_FLAG_MULTIPOINT_D_ROOT = 0x08
-      WSA_FLAG_MULTIPOINT_D_LEAF = 0x10
-      WSA_FLAG_ACCESS_SYSTEM_SECURITY = 0x40
-      WSA_FLAG_NO_HANDLE_INHERIT = 0x80
+    dlload "ws2_32.dll"
+    include Fiddle::Win32Types
 
-      # PROTOCOL
-      MAX_PROTOCOL_CHAIN = 7
-      WSAPROTOCOL_LENGTH = 256
-      GUID_DATA4_LENGTH = 8
-    end
+    extern "int WSASocketA(int, int, int, void *, int, DWORD)"
+    extern "long inet_addr(char *)"
+    extern "int bind(int, void *, int)"
+    extern "int listen(int, int)"
+    extern "int WSADuplicateSocketA(int, DWORD, void *)"
+    extern "int WSAGetLastError()"
 
-    include Constants
+    SockaddrIn = struct(["short sin_family",
+                         "short sin_port",
+                         "long sin_addr",
+                         "char sin_zero[8]",
+                        ])
 
-    typedef :ulong, :dword
-    typedef :uintptr_t, :socket
-    typedef :pointer, :ptr
-    typedef :ushort, :word
-    typedef :uintptr_t, :handle
+    WSAPROTOCOL_INFO = struct(["DWORD dwServiceFlags1",
+                               "DWORD dwServiceFlags2",
+                               "DWORD dwServiceFlags3",
+                               "DWORD dwServiceFlags4",
+                               "DWORD dwProviderFlags",
+                               "DWORD Data1",
+                               "WORD  Data2",
+                               "WORD  Data3",
+                               "BYTE  Data4[8]",
+                               "DWORD dwCatalogEntryId",
+                               "int ChainLen",
+                               "DWORD ChainEntries[7]",
+                               "int iVersion",
+                               "int iAddressFamily",
+                               "int iMaxSockAddr",
+                               "int iMinSockAddr",
+                               "int iSocketType",
+                               "int iProtocol",
+                               "int iProtocolMaxOffset",
+                               "int iNetworkByteOrder",
+                               "int iSecurityScheme",
+                               "DWORD dwMessageSize",
+                               "DWORD dwProviderReserved",
+                               "char szProtocol[256]",
+                              ])
 
-    ffi_lib :ws2_32
+  end
 
-    attach_function :closesocket, [:socket], :int
-    attach_function :inet_addr, [:string], :ulong
-
-    attach_function :FreeAddrInfoEx, [:pointer], :void
-    attach_function :GetAddrInfo, :getaddrinfo, [:string, :string, :pointer, :pointer], :int
-    attach_function :GetAddrInfoW, [:buffer_in, :buffer_in, :pointer, :pointer], :int
-
-    attach_function :GetAddrInfoExA, [:string, :string, :dword, :ptr, :ptr, :ptr, :ptr, :ptr, :ptr, :ptr], :int
-    attach_function :GetHostByAddr, :gethostbyaddr, [:string, :int, :int], :pointer
-    attach_function :GetHostByName, :gethostbyname, [:string], :pointer
-    attach_function :GetProtoByName, :getprotobyname, [:string], :ptr
-    attach_function :GetProtoByNumber, :getprotobynumber, [:int], :ptr
-    attach_function :GetHostName, :gethostname, [:buffer_out, :int], :int
-    attach_function :GetServByName,:getservbyname, [:string, :string], :pointer
-
-    attach_function :WSAAsyncGetHostByAddr, [:uintptr_t, :uint, :string, :int, :int, :buffer_out, :int], :uintptr_t
-    attach_function :WSAAsyncGetHostByName, [:uintptr_t, :uint, :string, :buffer_out, :pointer], :uintptr_t
-    attach_function :WSAAsyncGetProtoByName, [:uintptr_t, :uint, :string, :buffer_out, :pointer], :uintptr_t
-    attach_function :WSAAsyncGetProtoByNumber, [:uintptr_t, :uint, :int, :buffer_out, :pointer], :uintptr_t
-    attach_function :WSAAsyncGetServByName, [:uintptr_t, :uint, :int, :string, :buffer_out, :int], :uintptr_t
-    attach_function :WSAAsyncGetServByPort, [:uintptr_t, :uint, :int, :string, :buffer_out, :int], :uintptr_t
-    attach_function :WSACancelAsyncRequest, [:uintptr_t], :int
-    attach_function :WSACleanup, [], :int
-    attach_function :WSAConnect, [:socket, :ptr, :int, :ptr, :ptr, :ptr, :ptr], :int
-    attach_function :WSAConnectByNameA, [:socket, :string, :string, :ptr, :ptr, :ptr, :ptr, :ptr, :ptr], :bool
-    attach_function :WSAEnumNameSpaceProvidersA, [:ptr, :ptr], :int
-    attach_function :WSAEnumProtocolsA, [:ptr, :ptr, :ptr], :int
-    attach_function :WSAGetLastError, [], :int
-    attach_function :WSASocketA, [:int, :int, :int, :ptr, :int, :dword], :socket
-    attach_function :WSAStartup, [:word, :ptr], :int
-    attach_function :WSADuplicateSocketA, [:socket, :dword, :ptr], :int
-    attach_function :bind, [:socket, :ptr, :int], :int
-    attach_function :listen, [:socket, :int], :int
-    attach_function :WSAAccept, [:socket, :ptr, :int, :int, :int], :socket
-    attach_function :accept, [:socket, :ptr, :int], :socket
+  module WinSockWrapper
+    extend Fiddle::Importer
 
     rubydll_path = Dir.glob(RbConfig.expand("$(bindir)")+"/msvcr*ruby*.dll").first
-    ffi_lib rubydll_path
-    attach_function :rb_w32_wrap_io_handle, [:handle, :int], :int
+    dlload rubydll_path
 
-    class InAddr < FFI::Struct
-      layout(:s_addr, :ulong)
-    end
-
-    class SockaddrIn < FFI::Struct
-      layout(
-          :sin_family, :short,
-          :sin_port, :ushort,
-          :sin_addr, InAddr,
-          :sin_zero, [:char, 8]
-      )
-    end
-
-    class GUID < FFI::Struct
-      layout(:Data1, :dword, :Data2, :word, :Data3, :word, :Data4, [:uchar, 8])
-    end
-
-    class WSAPROTOCOL_CHAIN < FFI::Struct
-      layout(:ChainLen, :int, :ChainEntries, [:dword, 7])
-    end
-
-    class Sockaddr < FFI::Struct
-      layout(:sa_family, :ushort, :sa_data, [:char, 14])
-    end
-
-    class WSAPROTOCOL_INFO < FFI::Struct
-      layout(
-          :dwServiceFlags1, :dword,
-          :dwServiceFlags2, :dword,
-          :dwServiceFlags3, :dword,
-          :dwServiceFlags4, :dword,
-          :dwProviderFlags, :dword,
-          :ProviderID, GUID,
-          :dwCatalogEntryId, :dword,
-          :ProtocolChain, WSAPROTOCOL_CHAIN,
-          :iVersion, :int,
-          :iAddressFamily, :int,
-          :iMaxSockAddr, :int,
-          :iMinSockAddr, :int,
-          :iSocketType, :int,
-          :iProtocol, :int,
-          :iProtocolMaxOffset, :int,
-          :iNetworkByteOrder, :int,
-          :iSecurityScheme, :int,
-          :dwMessageSize, :dword,
-          :dwProviderReserved, :dword,
-          :szProtocol, [:char, 256]
-      )
-    end
-
-    def self.proto_to_map(proto)
-      {
-          :dwServiceFlags1 => proto[:dwServiceFlags1].to_s,
-          :dwServiceFlags2 =>  proto[:dwServiceFlags2].to_s,
-          :dwServiceFlags3 =>  proto[:dwServiceFlags3].to_s,
-          :dwServiceFlags4 =>  proto[:dwServiceFlags4].to_s,
-          :dwProviderFlags =>  proto[:dwProviderFlags].to_s,
-          :guid_data1 => proto[:ProviderID][:Data1].to_s,
-          :guid_data2 => proto[:ProviderID][:Data2].to_s,
-          :guid_data3 => proto[:ProviderID][:Data3].to_s,
-          :dwCatalogEntryId =>  proto[:dwCatalogEntryId].to_s,
-          :iVersion =>  proto[:iVersion].to_s,
-          :iAddressFamily =>  proto[:iAddressFamily].to_s,
-          :iMaxSockAddr =>  proto[:iMaxSockAddr].to_s,
-          :iMinSockAddr =>  proto[:iMinSockAddr].to_s,
-          :iSocketType =>  proto[:iSocketType].to_s,
-          :iProtocol =>  proto[:iProtocol].to_s,
-          :iProtocolMaxOffset =>  proto[:iProtocolMaxOffset].to_s,
-          :iNetworkByteOrder =>  proto[:iNetworkByteOrder].to_s,
-          :iSecurityScheme =>  proto[:iSecurityScheme].to_s,
-          :dwMessageSize =>  proto[:dwMessageSize].to_s,
-          :dwProviderReserved =>  proto[:dwProviderReserved].to_s,
-      }
-    end
-
-    def self.map_to_proto(proto_map)
-      proto = WSAPROTOCOL_INFO.new
-      proto[:dwServiceFlags1] =  proto_map[:dwServiceFlags1].to_i
-      proto[:dwServiceFlags2] =  proto_map[:dwServiceFlags2].to_i
-      proto[:dwServiceFlags3] =  proto_map[:dwServiceFlags3].to_i
-      proto[:dwServiceFlags4] =  proto_map[:dwServiceFlags4].to_i
-      proto[:dwProviderFlags] =  proto_map[:dwProviderFlags].to_i
-      proto[:ProviderID][:Data1] =  proto_map[:guid_data1].to_i
-      proto[:ProviderID][:Data2] =  proto_map[:guid_data2].to_i
-      proto[:ProviderID][:Data3] =  proto_map[:guid_data3].to_i
-      proto[:dwCatalogEntryId] =  proto_map[:dwCatalogEntryId].to_i
-      proto[:iVersion] =  proto_map[:iVersion].to_i
-      proto[:iAddressFamily] =  proto_map[:iAddressFamily].to_i
-      proto[:iMaxSockAddr] =  proto_map[:iMaxSockAddr].to_i
-      proto[:iMinSockAddr] =  proto_map[:iMinSockAddr].to_i
-      proto[:iSocketType] =  proto_map[:iSocketType].to_i
-      proto[:iProtocol] =  proto_map[:iProtocol].to_i
-      proto[:iProtocolMaxOffset] =  proto_map[:iProtocolMaxOffset].to_i
-      proto[:iNetworkByteOrder] =  proto_map[:iNetworkByteOrder].to_i
-      proto[:iSecurityScheme] =  proto_map[:iSecurityScheme].to_i
-      proto[:dwMessageSize] =  proto_map[:dwMessageSize].to_i
-      proto[:dwProviderReserved] =  proto_map[:dwProviderReserved].to_i
-      return proto
-    end
-
+    extern "int rb_w32_wrap_io_handle(int, int)"
   end
 end

--- a/lib/serverengine/winsock.rb
+++ b/lib/serverengine/winsock.rb
@@ -71,8 +71,16 @@ module ServerEngine
   module WinSockWrapper
     extend Fiddle::Importer
 
-    rubydll_path = Dir.glob(RbConfig.expand("$(bindir)")+"/msvcr*ruby*.dll").first
-    dlload rubydll_path
+    dlload "kernel32"
+    extern "int GetModuleFileNameA(int, char *, int)"
+
+    ruby_bin_path_buf = Fiddle::Pointer.malloc(1000)
+    GetModuleFileNameA(0, ruby_bin_path_buf, ruby_bin_path_buf.size)
+
+    ruby_bin_path = ruby_bin_path_buf.to_s.gsub(/\\/, '/')
+    ruby_dll_paths = File.dirname(ruby_bin_path) + '/msvcr*ruby*.dll'
+    ruby_dll_path = Dir.glob(ruby_dll_paths).first
+    dlload ruby_dll_path
 
     extern "int rb_w32_wrap_io_handle(int, int)"
   end

--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.3"
 
   gem.add_dependency "sigdump", ["~> 0.2.2"]
-  gem.add_dependency "ffi", [">= 1.9.10"]
 
   gem.add_development_dependency "rake", [">= 0.9.2"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]

--- a/spec/signal_thread_spec.rb
+++ b/spec/signal_thread_spec.rb
@@ -25,7 +25,7 @@ describe ServerEngine::SignalThread do
     # IGNORE signal handler has possible race condition in Ruby 2.1
     # https://bugs.ruby-lang.org/issues/9835
     # That's why ignore this test in Ruby2.1
-    unless /2.1/ === RUBY_VERSION
+    if RUBY_VERSION >= '2.2'
       t = SignalThread.new do |st|
         st.trap('QUIT', 'SIG_IGN')
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 require 'serverengine'
 include ServerEngine
 
+# require sigdump only in unix, because there is no suport for SIGCONT in windows.
 unless ServerEngine.windows?
   require 'sigdump/setup'
 end


### PR DESCRIPTION
I fixed 3 points mainly like below.
・Added API for generating path for Socket Manager
For now, it is difficult to generate singular port for windows by users.
Then I added API to generate path automatically.

・Fixed Socket Manager for Windows to use fiddle not ffi
Fiddle is safer than ffi, because fiddle is internal implementation of ruby.

・Fixed ruby_dll_path to use GetModuleFileName
Users can set RbConfig's path value arbitrarily in Windows.
Then GetModuleFileName is safer to get ruby dll path.
