### PR TITLE
Fix infinite self call

### DIFF
--- a/lib/serverengine/signal_thread.rb
+++ b/lib/serverengine/signal_thread.rb
@@ -54,7 +54,7 @@ module ServerEngine
     end
 
     def handlers
-      handlers.dup
+      @handlers.dup
     end
 
     def stop


### PR DESCRIPTION
Due to the problem, the following call causes "stack level too deep".

```
ruby -e 'require "serverengine"; ServerEngine::SignalThread.new.handlers'
```