### PR TITLE
Fix socket manager to identify all localhost address

### DIFF
--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -124,6 +124,9 @@ module ServerEngine
           return "[#{bind_ip}]:#{port}", bind_ip
         else
           # assuming ipv4
+          if bind_ip == "127.0.0.1" or bind_ip == "0.0.0.0"
+            return "localhost:#{port}", bind_ip
+          end
           return "#{bind_ip}:#{port}", bind_ip
         end
       end


### PR DESCRIPTION
For now, socket manager considers 127.0.0.1 and 0.0.0.0 as different ip addresses, so it tries to open localhost again and it shows "Address is already use" when using both 127.0.0.1 and 0.0.0.0.

Then we need to these addresses as same localhost address not to open again(to get socket from map).