### PR TITLE
Fix socket manager not to join thread in ruby2.1

### DIFF
--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -80,7 +80,8 @@ module ServerEngine
         @tcp_sockets.reject! {|key,lsock| lsock.close; true }
         @udp_sockets.reject! {|key,usock| usock.close; true }
         @server.close unless @server.closed?
-        @thread.join
+        # It cause dead lock and can't finish when joining thread using Ruby 2.1 on linux.
+        @thread.join if RUBY_VERSION >= "2.2"
       end
 
       def send_socket(peer, pid, method, bind, port)


### PR DESCRIPTION
It cause dead lock and can't finish when joining thread using Ruby 2.1 on linux.
As a temporary plan, I fixed not to join thread in ruby2.1.