### PR TITLE
Suppress Ruby warnings

### DIFF
--- a/lib/serverengine/config_loader.rb
+++ b/lib/serverengine/config_loader.rb
@@ -29,6 +29,8 @@ module ServerEngine
         end
       end
 
+      @logger = nil
+
       reload_config
     end
 

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -31,8 +31,8 @@ module ServerEngine
       @daemonize = @config.fetch(:daemonize, false)
 
       if @config.fetch(:supervisor, false)
-        @create_server_proc = lambda do |load_config_proc,logger|
-          s = Supervisor.new(server_module, worker_module, load_config_proc)
+        @create_server_proc = lambda do |_load_config_proc,logger|
+          s = Supervisor.new(server_module, worker_module, _load_config_proc)
           s.logger = logger
           s
         end

--- a/lib/serverengine/daemon_logger.rb
+++ b/lib/serverengine/daemon_logger.rb
@@ -32,6 +32,7 @@ module ServerEngine
     def initialize(logdev, config={})
       @rotate_age = config[:log_rotate_age] || 5
       @rotate_size = config[:log_rotate_size] || 1048576
+      @file_dev = nil
 
       if RUBY_VERSION < "2.1.0"
         # Ruby < 2.1.0 has a problem around log rotation with multiprocess:

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -149,7 +149,7 @@ module ServerEngine
       while true
         # keep the child process alive in this loop
         until @detach_flag.wait(0.5)
-          if stat = try_join
+          if try_join
             return if @stop   # supervisor stoppped explicitly
 
             # child process died unexpectedly.

--- a/spec/server_worker_context.rb
+++ b/spec/server_worker_context.rb
@@ -29,6 +29,88 @@ def test_state(key)
   return data[key] || 0
 end
 
+module TestServer
+  def initialize
+    incr_test_state :server_initialize
+  end
+
+  def before_run
+    incr_test_state :server_before_run
+  end
+
+  def after_run
+    incr_test_state :server_after_run
+  end
+
+  def after_start
+    incr_test_state :server_after_start
+  end
+
+  def stop(stop_graceful)
+    incr_test_state :server_stop
+    if stop_graceful
+      incr_test_state :server_stop_graceful
+    else
+      incr_test_state :server_stop_immediate
+    end
+    super
+  end
+
+  def restart(stop_graceful)
+    incr_test_state :server_restart
+    if stop_graceful
+      incr_test_state :server_restart_graceful
+    else
+      incr_test_state :server_restart_immediate
+    end
+    super
+  end
+
+  def reload
+    incr_test_state :server_reload
+    super
+  end
+
+  def detach
+    incr_test_state :server_detach
+    super
+  end
+end
+
+module TestWorker
+  def initialize
+    incr_test_state :worker_initialize
+    @stop_flag = BlockingFlag.new
+  end
+
+  def before_fork
+    incr_test_state :worker_before_fork
+  end
+
+  def run
+    incr_test_state :worker_run
+    5.times do
+      # repeats 5 times because signal handlers
+      # interrupts wait
+      @stop_flag.wait(5.0)
+    end
+    @stop_flag.reset!
+  end
+
+  def stop
+    incr_test_state :worker_stop
+    @stop_flag.set!
+  end
+
+  def reload
+    incr_test_state :worker_reload
+  end
+
+  def after_start
+    incr_test_state :worker_after_start
+  end
+end
+
 shared_context 'test server and worker' do
   before { reset_test_state }
 
@@ -43,87 +125,4 @@ shared_context 'test server and worker' do
   def wait_for_restart
     sleep 1.5
   end
-
-  module TestServer
-    def initialize
-      incr_test_state :server_initialize
-    end
-
-    def before_run
-      incr_test_state :server_before_run
-    end
-
-    def after_run
-      incr_test_state :server_after_run
-    end
-
-    def after_start
-      incr_test_state :server_after_start
-    end
-
-    def stop(stop_graceful)
-      incr_test_state :server_stop
-      if stop_graceful
-        incr_test_state :server_stop_graceful
-      else
-        incr_test_state :server_stop_immediate
-      end
-      super
-    end
-
-    def restart(stop_graceful)
-      incr_test_state :server_restart
-      if stop_graceful
-        incr_test_state :server_restart_graceful
-      else
-        incr_test_state :server_restart_immediate
-      end
-      super
-    end
-
-    def reload
-      incr_test_state :server_reload
-      super
-    end
-
-    def detach
-      incr_test_state :server_detach
-      super
-    end
-  end
-
-  module TestWorker
-    def initialize
-      incr_test_state :worker_initialize
-      @stop_flag = BlockingFlag.new
-    end
-
-    def before_fork
-      incr_test_state :worker_before_fork
-    end
-
-    def run
-      incr_test_state :worker_run
-      5.times do
-        # repeats 5 times because signal handlers
-        # interrupts wait
-        @stop_flag.wait(5.0)
-      end
-      @stop_flag.reset!
-    end
-
-    def stop
-      incr_test_state :worker_stop
-      @stop_flag.set!
-    end
-
-    def reload
-      incr_test_state :worker_reload
-    end
-
-    def after_start
-      incr_test_state :worker_after_start
-    end
-  end
-
 end

--- a/spec/signal_thread_spec.rb
+++ b/spec/signal_thread_spec.rb
@@ -39,7 +39,7 @@ describe ServerEngine::SignalThread do
   it 'signal in handler' do
     n = 0
 
-    t = SignalThread.new do |st|
+    SignalThread.new do |st|
       st.trap('QUIT') do
         if n < 3
           Process.kill('QUIT', Process.pid)
@@ -55,8 +55,6 @@ describe ServerEngine::SignalThread do
   end
 
   it 'stop in handler' do
-    n = 0
-
     t = SignalThread.new do |st|
       st.trap('QUIT') { st.stop }
     end
@@ -70,7 +68,7 @@ describe ServerEngine::SignalThread do
   it 'should not deadlock' do
     n = 0
 
-    t = SignalThread.new do |st|
+    SignalThread.new do |st|
       st.trap('CONT') { n += 1 }
     end
 

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -7,7 +7,7 @@ describe ServerEngine::SocketManager do
   end
 
   after(:each) do
-    File.unlink(server_path) if File.exists?(server_path)
+    File.unlink(server_path) if File.exist?(server_path)
   end
 
   if ServerEngine.windows?

--- a/spec/socket_manager_spec.rb
+++ b/spec/socket_manager_spec.rb
@@ -37,7 +37,7 @@ describe ServerEngine::SocketManager do
           incr_test_state(:is_tcp_server) if tcp.is_a?(TCPServer)
           incr_test_state(:is_udp_socket) if udp.is_a?(UDPSocket)
 
-          data, from = udp.recvfrom(10)
+          data, _from = udp.recvfrom(10)
           incr_test_state(:udp_data_sent) if data == "ok"
 
           s = tcp.accept
@@ -89,7 +89,7 @@ describe ServerEngine::SocketManager do
           incr_test_state(:is_tcp_server) if tcp.is_a?(TCPServer)
           incr_test_state(:is_udp_socket) if udp.is_a?(UDPSocket)
 
-          data, from = udp.recvfrom(10)
+          data, _from = udp.recvfrom(10)
           incr_test_state(:udp_data_sent) if data == "ok"
 
           s = tcp.accept


### PR DESCRIPTION
```
$ RUBYOPT="-w -v" bundle exec rake
```

Fluentd uses ServerEngine on Fluentd master branch.
I've worked to eliminate warning messages that is
reported when running Fluentd's test.
Some warning messages are reported from ServerEngine's code
when I execute Fluentd's test.