### PR TITLE
Adding fence for safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 tmp/*
 pkg/*
+myserver.log
+myserver.pid

--- a/example/server.rb
+++ b/example/server.rb
@@ -1,0 +1,86 @@
+require 'serverengine'
+
+require 'json'
+require 'optparse'
+
+# This is a script to run ServerEngine and SocketManager as a real process.
+# bundle exec ruby example/server.rb [-t TYPE] [-w NUM]
+# available type of workers are: embedded(default), process, thread, spawn
+
+worker_type = nil
+workers = 4
+
+opt = OptionParser.new
+opt.on('-t TYPE'){|v| worker_type = v }
+opt.on('-w NUM'){|v| workers = v.to_i }
+opt.parse!(ARGV)
+
+module MyServer
+  attr_reader :socket_manager_path
+
+  def before_run
+    @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
+    @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)
+  rescue Exception => e
+    logger.error "unexpected error in server, class #{e.class}: #{e.message}"
+    raise
+  end
+
+  def after_run
+    @socket_manager_server.close
+  end
+end
+
+module MyWorker
+  def initialize
+    @stop = false
+    @socket_manager = ServerEngine::SocketManager::Client.new(server.socket_manager_path)
+  end
+
+  def main
+    # test to listen the same port
+    _listen_sock = @socket_manager.listen_tcp('0.0.0.0', 12345)
+    until @stop
+      logger.info "Awesome work!"
+      sleep 1
+    end
+    logger.info "Exitting"
+  rescue Exception => e
+    logger.warn "unexpected error, class #{e.class}: #{e.message}"
+    raise
+  end
+
+  def stop
+    @stop = true
+  end
+end
+
+module MySpawnWorker
+  def spawn(process_manager)
+    env = {
+      'SERVER_ENGINE_CONFIG' => config.to_json,
+      'SERVER_ENGINE_SOCKET_MANAGER_PATH' => server.socket_manager_path,
+    }
+    process_manager.spawn(env, "ruby", File.expand_path("../spawn_worker_script.rb", __FILE__))
+  rescue Exception => e
+    logger.error "unexpected error, class #{e.class}: #{e.message}"
+    raise
+  end
+end
+
+opts = {
+  daemonize: true,
+  daemon_process_name: 'mydaemon',
+  log: 'myserver.log',
+  pid_path: 'myserver.pid',
+  worker_type: worker_type,
+  workers: workers,
+}
+
+worker_klass = MyWorker
+if worker_type == 'spawn'
+  worker_klass = MySpawnWorker
+end
+se = ServerEngine.create(MyServer, worker_klass, opts)
+
+se.run

--- a/example/spawn_worker_script.rb
+++ b/example/spawn_worker_script.rb
@@ -1,0 +1,23 @@
+$LOAD_PATH.unshift File.expand_path("../..", __FILE__)
+
+require 'serverengine'
+require 'json'
+
+begin
+  conf = JSON.parse(ENV['SERVER_ENGINE_CONFIG'], symbolize_names: true)
+  logger = ServerEngine::DaemonLogger.new(conf[:log] || STDOUT, conf)
+  socket_manager = ServerEngine::SocketManager::Client.new(ENV['SERVER_ENGINE_SOCKET_MANAGER_PATH'])
+
+  @stop = false
+  trap(:SIGTERM) { @stop = true }
+  trap(:SIGINT) { @stop = true }
+
+  _listen_sock = socket_manager.listen_tcp('0.0.0.0', 12345)
+  until @stop
+    logger.info 'Awesome work!'
+    sleep 1
+  end
+  logger.info 'Exitting'
+rescue Exception => e
+  logger.error "unexpected error in spawn worker, class #{e.class}: #{e.message}"
+end

--- a/lib/serverengine.rb
+++ b/lib/serverengine.rb
@@ -19,34 +19,15 @@ module ServerEngine
 
   require 'sigdump'
 
-  here = File.expand_path(File.dirname(__FILE__))
+  require 'serverengine/version'
 
-  {
-    :BlockingFlag => 'serverengine/blocking_flag',
-    :SignalThread => 'serverengine/signal_thread',
-    :DaemonLogger => 'serverengine/daemon_logger',
-    :ConfigLoader => 'serverengine/config_loader',
-    :Daemon => 'serverengine/daemon',
-    :Supervisor => 'serverengine/supervisor',
-    :Server => 'serverengine/server',
-    :EmbeddedServer => 'serverengine/embedded_server',
-    :MultiWorkerServer => 'serverengine/multi_worker_server',
-    :MultiProcessServer => 'serverengine/multi_process_server',
-    :MultiThreadServer => 'serverengine/multi_thread_server',
-    :MultiSpawnServer => 'serverengine/multi_spawn_server',
-    :ProcessManager => 'serverengine/process_manager',
-    :SocketManager => 'serverengine/socket_manager',
-    :Worker => 'serverengine/worker',
-    :VERSION => 'serverengine/version',
-  }.each_pair {|k,v|
-    autoload k, File.expand_path(v, File.dirname(__FILE__))
-  }
+  require 'serverengine/utils' # ServerEngine.windows?
 
-  [
-    'serverengine/utils',
-  ].each {|v|
-    require File.join(here, v)
-  }
+  require 'serverengine/daemon'
+  require 'serverengine/supervisor'
+  require 'serverengine/server'
+  require 'serverengine/worker'
+  require 'serverengine/socket_manager'
 
   def self.create(server_module, worker_module, load_config_proc={}, &block)
     Daemon.new(server_module, worker_module, load_config_proc, &block)

--- a/lib/serverengine/blocking_flag.rb
+++ b/lib/serverengine/blocking_flag.rb
@@ -15,10 +15,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'thread'
+
 module ServerEngine
-
-  require 'thread'
-
   class BlockingFlag
     def initialize
       @set = false
@@ -74,5 +73,4 @@ module ServerEngine
       end
     end
   end
-
 end

--- a/lib/serverengine/config_loader.rb
+++ b/lib/serverengine/config_loader.rb
@@ -15,6 +15,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'serverengine/daemon_logger'
+
 module ServerEngine
 
   module ConfigLoader

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -15,9 +15,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-module ServerEngine
 
-  require 'shellwords'
+require 'serverengine/privilege'
+require 'serverengine/config_loader'
+require 'serverengine/supervisor'
+
+module ServerEngine
 
   class Daemon
     include ConfigLoader
@@ -52,51 +55,6 @@ module ServerEngine
     # server is available when run() is called. It is a Supervisor instance if supervisor is set to true. Otherwise a Server instance.
     attr_reader :server
 
-    module Signals
-      GRACEFUL_STOP = :TERM
-      IMMEDIATE_STOP = :QUIT
-      GRACEFUL_RESTART = :USR1
-      IMMEDIATE_RESTART = :HUP
-      RELOAD = :USR2
-      DETACH = :INT
-      DUMP = :CONT
-    end
-
-    def self.get_etc_passwd(user)
-      if user.to_i.to_s == user
-        Etc.getpwuid(user.to_i)
-      else
-        Etc.getpwnam(user)
-      end
-    end
-
-    def self.get_etc_group(group)
-      if group.to_i.to_s == group
-        Etc.getgrgid(group.to_i)
-      else
-        Etc.getgrnam(group)
-      end
-    end
-
-    def self.change_privilege(user, group)
-      if user
-        etc_pw = Daemon.get_etc_passwd(user)
-        user_groups = [etc_pw.gid]
-        Etc.setgrent
-        Etc.group { |gr| user_groups << gr.gid if gr.mem.include?(etc_pw.name) } # emulate 'id -G'
-
-        Process.groups = Process.groups | user_groups
-        Process::UID.change_privilege(etc_pw.uid)
-      end
-
-      if group
-        etc_group = Daemon.get_etc_group(group)
-        Process::GID.change_privilege(etc_group.gid)
-      end
-
-      nil
-    end
-
     def run
       begin
         exit main
@@ -113,7 +71,7 @@ module ServerEngine
     def server_main
       $0 = @daemon_process_name if @daemon_process_name
 
-      Daemon.change_privilege(@chuser, @chgroup)
+      Privilege.change_privilege(@chuser, @chgroup)
       File.umask(@chumask) if @chumask
 
       s = create_server(create_logger)
@@ -152,7 +110,7 @@ module ServerEngine
               $0 = @daemon_process_name if @daemon_process_name
               wpipe.write "#{Process.pid}\n"
 
-              Daemon.change_privilege(@chuser, @chgroup)
+              Privilege.change_privilege(@chuser, @chgroup)
               File.umask(@chumask) if @chumask
 
               s = create_server(create_logger)

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -124,6 +124,8 @@ module ServerEngine
               wpipe.write "\n"
               wpipe.close
 
+              logger.debug "calling Server#main at #{Process.pid}"
+
               s.main
             end
 

--- a/lib/serverengine/daemon_logger.rb
+++ b/lib/serverengine/daemon_logger.rb
@@ -15,9 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-module ServerEngine
 
-  require 'logger'
+require 'logger'
+
+module ServerEngine
 
   class ::Logger::LogDevice
     def reopen!

--- a/lib/serverengine/embedded_server.rb
+++ b/lib/serverengine/embedded_server.rb
@@ -15,6 +15,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'serverengine/server'
+
 module ServerEngine
 
   class EmbeddedServer < Server

--- a/lib/serverengine/monitor.rb
+++ b/lib/serverengine/monitor.rb
@@ -1,0 +1,115 @@
+#
+# ServerEngine
+#
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'serverengine/utils'
+require 'serverengine/signals'
+
+module ServerEngine
+  module Monitor
+    class ProcessWorkerMonitor
+      def initialize(worker, wid, pmon)
+        @worker = worker
+        @wid = wid
+        @pmon = pmon
+      end
+
+      def send_stop(stop_graceful)
+        @stop = true
+        if stop_graceful
+          @pmon.start_graceful_stop! if @pmon
+        else
+          @pmon.start_immediate_stop! if @pmon
+        end
+        nil
+      end
+
+      def send_reload
+        @pmon.send_signal(Signals::RELOAD) if @pmon
+        nil
+      end
+
+      def join
+        @pmon.join if @pmon
+        nil
+      end
+
+      def alive?
+        return false unless @pmon
+
+        if stat = @pmon.try_join
+          @worker.logger.info "Worker #{@wid} finished#{@stop ? '' : ' unexpectedly'} with #{ServerEngine.format_join_status(stat)}"
+          @pmon = nil
+          return false
+        else
+          return true
+        end
+      end
+    end
+
+    class SpawnWorkerMonitor < ProcessWorkerMonitor
+      def initialize(worker, wid, pmon, reload_signal)
+        super(worker, wid, pmon)
+        @reload_signal = reload_signal
+      end
+
+      def send_reload
+        if @reload_signal
+          @pmon.send_signal(@reload_signal) if @pmon
+        end
+        nil
+      end
+    end
+
+    class ThreadWorkerMonitor
+      def initialize(worker, thread)
+        @worker = worker
+        @thread = thread
+      end
+
+      def send_stop(stop_graceful)
+        Thread.new do
+          begin
+            @worker.stop
+          rescue => e
+            ServerEngine.dump_uncaught_error(e)
+          end
+        end
+        nil
+      end
+
+      def send_reload
+        Thread.new do
+          begin
+            @worker.reload
+          rescue => e
+            ServerEngine.dump_uncaught_error(e)
+          end
+        end
+        nil
+      end
+
+      def join
+        @thread.join
+      end
+
+      def alive?
+        @thread.alive?
+      end
+    end
+  end
+end

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -70,6 +70,10 @@ module ServerEngine
       nil
     end
 
+    def spawn(process_manager)
+      raise NotImplementedError
+    end
+
     def start_worker(wid)
       w = create_worker(wid)
 

--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -15,6 +15,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'serverengine/server'
+
 module ServerEngine
 
   class MultiWorkerServer < Server
@@ -23,6 +26,10 @@ module ServerEngine
       @last_start_worker_time = 0
 
       super(worker_module, load_config_proc, &block)
+    end
+
+    def start_worker(wid)
+      raise NotImplementedError, "Use child class instead of using this class"
     end
 
     def stop(stop_graceful)

--- a/lib/serverengine/privilege.rb
+++ b/lib/serverengine/privilege.rb
@@ -1,0 +1,61 @@
+#
+# ServerEngine
+#
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+require 'serverengine/utils'
+require 'etc' unless ServerEngine.windows?
+
+module ServerEngine
+  module Privilege
+    def self.get_etc_passwd(user)
+      if user.to_i.to_s == user
+        Etc.getpwuid(user.to_i)
+      else
+        Etc.getpwnam(user)
+      end
+    end
+
+    def self.get_etc_group(group)
+      if group.to_i.to_s == group
+        Etc.getgrgid(group.to_i)
+      else
+        Etc.getgrnam(group)
+      end
+    end
+
+    def self.change_privilege(user, group)
+      raise "Changing privileges is not supported on this platform" if ServerEngine.windows?
+
+      if user
+        etc_pw = Daemon.get_etc_passwd(user)
+        user_groups = [etc_pw.gid]
+        Etc.setgrent
+        Etc.group { |gr| user_groups << gr.gid if gr.mem.include?(etc_pw.name) } # emulate 'id -G'
+
+        Process.groups = Process.groups | user_groups
+        Process::UID.change_privilege(etc_pw.uid)
+      end
+
+      if group
+        etc_group = Daemon.get_etc_group(group)
+        Process::GID.change_privilege(etc_group.gid)
+      end
+
+      nil
+    end
+  end
+end

--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -15,9 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-module ServerEngine
 
-  require 'fcntl'
+require 'fcntl'
+
+module ServerEngine
 
   class ProcessManager
     def initialize(config={})
@@ -113,7 +114,7 @@ module ServerEngine
 
     def fork(&block)
       if ServerEngine.windows?
-        raise NotImplementedError, "fork is not available on this platform. Please use spawn (worker_type: 'spawn')."
+        raise "fork is not available on this platform. Please use spawn (worker_type: 'spawn')."
       end
 
       rpipe, wpipe = new_pipe_pair
@@ -266,28 +267,6 @@ module ServerEngine
       nil
     end
 
-    def self.format_signal_name(n)
-      Signal.list.each_pair {|k,v|
-        return "SIG#{k}" if n == v
-      }
-      return n
-    end
-
-    def self.format_join_status(code)
-      case code
-      when Process::Status
-        if code.signaled?
-          "signal #{format_signal_name(code.termsig)}"
-        else
-          "status #{code.exitstatus}"
-        end
-      when Exception
-        "exception #{code}"
-      when nil
-        "unknown reason"
-      end
-    end
-
     class AlreadyClosedError < EOFError
     end
 
@@ -297,18 +276,18 @@ module ServerEngine
       def initialize(pid, opts={})
         @pid = pid
 
-        @enable_heartbeat = kwargs[:enable_heartbeat]
-        @heartbeat_timeout = kwargs[:heartbeat_timeout]
+        @enable_heartbeat = opts[:enable_heartbeat]
+        @heartbeat_timeout = opts[:heartbeat_timeout]
 
-        @graceful_kill_signal   = kwargs[:graceful_kill_signal]
-        @graceful_kill_timeout  = kwargs[:graceful_kill_timeout]
-        @graceful_kill_interval = kwargs[:graceful_kill_interval]
-        @graceful_kill_interval_increment = kwargs[:graceful_kill_interval_increment]
+        @graceful_kill_signal   = opts[:graceful_kill_signal]
+        @graceful_kill_timeout  = opts[:graceful_kill_timeout]
+        @graceful_kill_interval = opts[:graceful_kill_interval]
+        @graceful_kill_interval_increment = opts[:graceful_kill_interval_increment]
 
-        @immediate_kill_signal   = kwargs[:immediate_kill_signal]
-        @immediate_kill_timeout  = kwargs[:immediate_kill_timeout]
-        @immediate_kill_interval = kwargs[:immediate_kill_interval]
-        @immediate_kill_interval_increment = kwargs[:immediate_kill_interval_increment]
+        @immediate_kill_signal   = opts[:immediate_kill_signal]
+        @immediate_kill_timeout  = opts[:immediate_kill_timeout]
+        @immediate_kill_interval = opts[:immediate_kill_interval]
+        @immediate_kill_interval_increment = opts[:immediate_kill_interval_increment]
 
         @error = false
         @last_heartbeat_time = Time.now

--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -57,7 +57,7 @@ module ServerEngine
       @read_buffer = ''
 
       if @auto_tick
-        TickThread.new(self)
+        TickThread.new(@auto_tick_interval, &method(:tick))
       end
     end
 
@@ -96,6 +96,21 @@ module ServerEngine
       }
     end
 
+    def monitor_options
+      {
+        enable_heartbeat: @enable_heartbeat,
+        heartbeat_timeout: @heartbeat_timeout,
+        graceful_kill_signal: @graceful_kill_signal,
+        graceful_kill_timeout: @graceful_kill_timeout,
+        graceful_kill_interval: @graceful_kill_interval,
+        graceful_kill_interval_increment: @graceful_kill_interval_increment,
+        immediate_kill_signal: @immediate_kill_signal,
+        immediate_kill_timeout: @immediate_kill_timeout,
+        immediate_kill_interval: @immediate_kill_interval,
+        immediate_kill_interval_increment: @immediate_kill_interval_increment,
+      }
+    end
+
     def fork(&block)
       if ServerEngine.windows?
         raise NotImplementedError, "fork is not available on this platform. Please use spawn (worker_type: 'spawn')."
@@ -109,7 +124,7 @@ module ServerEngine
           begin
             t = Target.new(wpipe)
             if @enable_heartbeat && @auto_heartbeat
-              HeartbeatThread.new(self, t, @heartbeat_error_proc)
+              HeartbeatThread.new(@heartbeat_interval, t, @heartbeat_error_proc)
             end
 
             block.call(t)
@@ -122,7 +137,7 @@ module ServerEngine
           end
         end
 
-        m = Monitor.new(self, pid)
+        m = Monitor.new(pid, monitor_options)
 
         @monitors << m
         @rpipes[rpipe] = m
@@ -163,7 +178,7 @@ module ServerEngine
 
         pid = Process.spawn(env, *args, options)
 
-        m = Monitor.new(self, pid)
+        m = Monitor.new(pid, monitor_options)
 
         @monitors << m
 
@@ -279,9 +294,21 @@ module ServerEngine
     HEARTBEAT_MESSAGE = [0].pack('C')
 
     class Monitor
-      def initialize(pm, pid)
-        @pm = pm
+      def initialize(pid, opts={})
         @pid = pid
+
+        @enable_heartbeat = kwargs[:enable_heartbeat]
+        @heartbeat_timeout = kwargs[:heartbeat_timeout]
+
+        @graceful_kill_signal   = kwargs[:graceful_kill_signal]
+        @graceful_kill_timeout  = kwargs[:graceful_kill_timeout]
+        @graceful_kill_interval = kwargs[:graceful_kill_interval]
+        @graceful_kill_interval_increment = kwargs[:graceful_kill_interval_increment]
+
+        @immediate_kill_signal   = kwargs[:immediate_kill_signal]
+        @immediate_kill_timeout  = kwargs[:immediate_kill_timeout]
+        @immediate_kill_interval = kwargs[:immediate_kill_interval]
+        @immediate_kill_interval_increment = kwargs[:immediate_kill_interval_increment]
 
         @error = false
         @last_heartbeat_time = Time.now
@@ -367,13 +394,13 @@ module ServerEngine
           # check heartbeat timeout or escalation
           if (
               # heartbeat timeout
-              @pm.enable_heartbeat &&
-              heartbeat_delay >= @pm.heartbeat_timeout
+              @enable_heartbeat &&
+              heartbeat_delay >= @heartbeat_timeout
              ) || (
                # escalation
                @graceful_kill_start_time &&
-               @pm.graceful_kill_timeout >= 0 &&
-               @graceful_kill_start_time < now - @pm.graceful_kill_timeout
+               @graceful_kill_timeout >= 0 &&
+               @graceful_kill_start_time < now - @graceful_kill_timeout
              )
             # escalate to immediate kill
             @kill_count = 0
@@ -390,20 +417,20 @@ module ServerEngine
         # send signal now
 
         if @immediate_kill_start_time
-          interval = @pm.immediate_kill_interval
-          interval_incr = @pm.immediate_kill_interval_increment
-          if @pm.immediate_kill_timeout >= 0 &&
-              @immediate_kill_start_time <= now - @pm.immediate_kill_timeout
+          interval = @immediate_kill_interval
+          interval_incr = @immediate_kill_interval_increment
+          if @immediate_kill_timeout >= 0 &&
+              @immediate_kill_start_time <= now - @immediate_kill_timeout
             # escalate to SIGKILL
             signal = :KILL
           else
-            signal = @pm.immediate_kill_signal
+            signal = @immediate_kill_signal
           end
 
         else
-          signal = @pm.graceful_kill_signal
-          interval = @pm.graceful_kill_interval
-          interval_incr = @pm.graceful_kill_interval_increment
+          signal = @graceful_kill_signal
+          interval = @graceful_kill_interval
+          interval_incr = @graceful_kill_interval_increment
         end
 
         begin
@@ -427,8 +454,9 @@ module ServerEngine
     end
 
     class TickThread < Thread
-      def initialize(pm)
-        @pm = pm
+      def initialize(auto_tick_interval, &tick)
+        @auto_tick_interval = auto_tick_interval
+        @tick = tick
         super(&method(:main))
       end
 
@@ -436,7 +464,7 @@ module ServerEngine
 
       def main
         while true
-          @pm.tick(@pm.auto_tick_interval)
+          @tick.call(@auto_tick_interval)
         end
         nil
       rescue AlreadyClosedError
@@ -464,8 +492,8 @@ module ServerEngine
     end
 
     class HeartbeatThread < Thread
-      def initialize(pm, target, error_proc)
-        @pm = pm
+      def initialize(heartbeat_interval, target, error_proc)
+        @heartbeat_interval = heartbeat_interval
         @target = target
         @error_proc = error_proc
         super(&method(:main))
@@ -475,7 +503,7 @@ module ServerEngine
 
       def main
         while true
-          sleep @pm.heartbeat_interval
+          sleep @heartbeat_interval
           @target.heartbeat!
         end
         nil

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -15,6 +15,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'serverengine/utils'
+require 'serverengine/signals'
+require 'serverengine/signal_thread'
+require 'serverengine/worker'
+
 module ServerEngine
 
   class Server
@@ -65,16 +71,16 @@ module ServerEngine
     def install_signal_handlers
       s = self
       SignalThread.new do |st|
-        st.trap(@config[:signal_graceful_stop] || Daemon::Signals::GRACEFUL_STOP) { s.stop(true) }
-        st.trap(@config[:signal_detach] || Daemon::Signals::DETACH) { s.stop(true) }
+        st.trap(@config[:signal_graceful_stop] || Signals::GRACEFUL_STOP) { s.stop(true) }
+        st.trap(@config[:signal_detach] || Signals::DETACH) { s.stop(true) }
         # Here disables signals excepting GRACEFUL_STOP == :SIGTERM because
         # only SIGTERM is available on all version of Windows.
         unless ServerEngine.windows?
-          st.trap(@config[:signal_immediate_stop] || Daemon::Signals::IMMEDIATE_STOP) { s.stop(false) }
-          st.trap(@config[:signal_graceful_restart] || Daemon::Signals::GRACEFUL_RESTART) { s.restart(true) }
-          st.trap(@config[:signal_immediate_restart] || Daemon::Signals::IMMEDIATE_RESTART) { s.restart(false) }
-          st.trap(@config[:signal_reload] || Daemon::Signals::RELOAD) { s.reload }
-          st.trap(@config[:signal_dump] || Daemon::Signals::DUMP) { Sigdump.dump }
+          st.trap(@config[:signal_immediate_stop] || Signals::IMMEDIATE_STOP) { s.stop(false) }
+          st.trap(@config[:signal_graceful_restart] || Signals::GRACEFUL_RESTART) { s.restart(true) }
+          st.trap(@config[:signal_immediate_restart] || Signals::IMMEDIATE_RESTART) { s.restart(false) }
+          st.trap(@config[:signal_reload] || Signals::RELOAD) { s.reload }
+          st.trap(@config[:signal_dump] || Signals::DUMP) { Sigdump.dump }
         end
       end
     end

--- a/lib/serverengine/signal_thread.rb
+++ b/lib/serverengine/signal_thread.rb
@@ -15,6 +15,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'serverengine/utils'
+
 module ServerEngine
 
   class SignalThread < Thread

--- a/lib/serverengine/signals.rb
+++ b/lib/serverengine/signals.rb
@@ -1,7 +1,7 @@
 #
 # ServerEngine
 #
-# Copyright (C) 2012-2013 Sadayuki Furuhashi
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -16,24 +16,14 @@
 #    limitations under the License.
 #
 
-require 'serverengine/monitor'
-require 'serverengine/multi_worker_server'
-
 module ServerEngine
-  class MultiThreadServer < MultiWorkerServer
-    private
-
-    def start_worker(wid)
-      w = create_worker(wid)
-
-      w.before_fork
-      begin
-        thread = Thread.new(&w.method(:main))
-      ensure
-        w.after_start
-      end
-
-      return Monitor::ThreadWorkerMonitor.new(w, thread)
-    end
+  module Signals
+    GRACEFUL_STOP = :TERM
+    IMMEDIATE_STOP = :QUIT
+    GRACEFUL_RESTART = :USR1
+    IMMEDIATE_RESTART = :HUP
+    RELOAD = :USR2
+    DETACH = :INT
+    DUMP = :CONT
   end
 end

--- a/lib/serverengine/socket_manager.rb
+++ b/lib/serverengine/socket_manager.rb
@@ -15,12 +15,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'socket'
+require 'ipaddr'
+
+require 'serverengine/utils'
+
 module ServerEngine
   module SocketManager
-
-    require 'socket'
-    require 'ipaddr'
-
     class Client
       def initialize(path)
         @path = path
@@ -156,8 +158,6 @@ module ServerEngine
       data = peer.read(len)
       Marshal.load(data)
     end
-
-    require_relative 'utils'
 
     if ServerEngine.windows?
       require_relative 'socket_manager_win'

--- a/lib/serverengine/socket_manager_unix.rb
+++ b/lib/serverengine/socket_manager_unix.rb
@@ -16,6 +16,10 @@
 #    limitations under the License.
 #
 
+require 'serverengine/utils'
+
+require 'socket'
+
 module ServerEngine
   module SocketManagerUnix
 

--- a/lib/serverengine/socket_manager_win.rb
+++ b/lib/serverengine/socket_manager_win.rb
@@ -16,11 +16,13 @@
 #    limitations under the License.
 #
 
+require_relative 'winsock'
+
+require 'socket'
+require 'ipaddr'
+
 module ServerEngine
   module SocketManagerWin
-
-    require_relative 'winsock'
-
     module ClientModule
       private
 

--- a/lib/serverengine/utils.rb
+++ b/lib/serverengine/utils.rb
@@ -36,4 +36,25 @@ module ServerEngine
 
   extend ClassMethods
 
+  def self.format_signal_name(n)
+    Signal.list.each_pair {|k,v|
+      return "SIG#{k}" if n == v
+    }
+    return n
+  end
+
+  def self.format_join_status(code)
+    case code
+    when Process::Status
+      if code.signaled?
+        "signal #{format_signal_name(code.termsig)}"
+      else
+        "status #{code.exitstatus}"
+      end
+    when Exception
+      "exception #{code}"
+    when nil
+      "unknown reason"
+    end
+  end
 end

--- a/lib/serverengine/worker.rb
+++ b/lib/serverengine/worker.rb
@@ -15,6 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+
+require 'serverengine/signals'
+require 'serverengine/signal_thread'
+
 module ServerEngine
 
   class Worker
@@ -35,11 +39,11 @@ module ServerEngine
     end
 
     def run
-      raise NoMethodError, "Worker#run method is not implemented"
+      raise NotImplementedError, "Worker#run method is not implemented"
     end
 
     def spawn(process_manager)
-      raise NoMethodError, "Worker#spawn(process_manager) method is required for worker_type=spawn"
+      raise NotImplementedError, "Worker#spawn(process_manager) method is required for worker_type=spawn"
     end
 
     def stop
@@ -54,19 +58,19 @@ module ServerEngine
     def install_signal_handlers
       w = self
       SignalThread.new do |st|
-        st.trap(Daemon::Signals::GRACEFUL_STOP) { w.stop }
-        st.trap(Daemon::Signals::IMMEDIATE_STOP, 'SIG_DFL')
+        st.trap(Signals::GRACEFUL_STOP) { w.stop }
+        st.trap(Signals::IMMEDIATE_STOP, 'SIG_DFL')
 
-        st.trap(Daemon::Signals::GRACEFUL_RESTART) { w.stop }
-        st.trap(Daemon::Signals::IMMEDIATE_RESTART, 'SIG_DFL')
+        st.trap(Signals::GRACEFUL_RESTART) { w.stop }
+        st.trap(Signals::IMMEDIATE_RESTART, 'SIG_DFL')
 
-        st.trap(Daemon::Signals::RELOAD) {
+        st.trap(Signals::RELOAD) {
           w.logger.reopen!
           w.reload
         }
-        st.trap(Daemon::Signals::DETACH) { w.stop }
+        st.trap(Signals::DETACH) { w.stop }
 
-        st.trap(Daemon::Signals::DUMP) { Sigdump.dump }
+        st.trap(Signals::DUMP) { Sigdump.dump }
       end
     end
 


### PR DESCRIPTION
The code of ServerEngine has many points not good. For example:

* ProcessManager and classes of ProcessManager::* are tightly coupled by sharing instance of ProcessManager, but there are no reason to do it
* All modules are loaded via autoload, but it makes code and dependency between files unclear
* Etc module is used but it's unavailable in Windows, so it should be separated from main code

I fixed these things (mainly for following fixes to fix process control on Windows platform).
I also added an example script to run ServerEngine with SocketManager actually to show it works well with each worker types.