### PR TITLE
Send/recieve commands via pipe instead of sending signals

### DIFF
--- a/lib/serverengine.rb
+++ b/lib/serverengine.rb
@@ -37,6 +37,7 @@ module ServerEngine
     :ProcessManager => 'serverengine/process_manager',
     :SocketManager => 'serverengine/socket_manager',
     :Worker => 'serverengine/worker',
+    :CommandSender => 'serverengine/command_sender',
     :VERSION => 'serverengine/version',
   }.each_pair {|k,v|
     autoload k, File.expand_path(v, File.dirname(__FILE__))

--- a/lib/serverengine/command_sender.rb
+++ b/lib/serverengine/command_sender.rb
@@ -1,0 +1,47 @@
+#
+# ServerEngine
+#
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+module ServerEngine
+  module CommandSender
+    module Signal
+      # requires @pid
+      def stop(graceful)
+        Process.kill(!ServerEngine.windows? && graceful ? Daemon::Signals::GRACEFUL_STOP : Daemon::Signals::IMMEDIATE_STOP, @pid)
+      end
+
+      def restart(graceful)
+        Process.kill(graceful ? Daemon::Signals::GRACEFUL_RESTART : Daemon::Signals::IMMEDIATE_RESTART, @pid)
+      end
+
+      def reload
+        Process.kill(Daemon::Signals::RELOAD, @pid)
+      end
+
+      def detach
+        Process.kill(Daemon::Signals::DETACH, @pid)
+      end
+
+      def dump
+        Process.kill(Daemon::Signals::DUMP, @pid)
+      end
+    end
+
+    module Pipe
+      # requires @command_pipe
+    end
+  end
+end

--- a/lib/serverengine/command_sender.rb
+++ b/lib/serverengine/command_sender.rb
@@ -42,6 +42,25 @@ module ServerEngine
 
     module Pipe
       # requires @command_pipe
+      def stop(graceful)
+        @command_pipe.write graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n"
+      end
+
+      def restart(graceful)
+        @command_pipe.write graceful ? "GRACEFUL_RESTART\n" : "IMMEDIATE_RESTART\n"
+      end
+
+      def reload
+        @command_pipe.write "RELOAD\n"
+      end
+
+      def detach
+        @command_pipe.write "DETACH\n"
+      end
+
+      def dump
+        @command_pipe.write "DUMP\n"
+      end
     end
   end
 end

--- a/lib/serverengine/command_sender.rb
+++ b/lib/serverengine/command_sender.rb
@@ -49,7 +49,7 @@ module ServerEngine
       end
     end
 
-    # requires @command_pipe
+    # requires @command_sender_pipe
     module Pipe
       private
       def _stop(graceful)
@@ -58,8 +58,8 @@ module ServerEngine
         rescue Errno::EPIPE
           # already stopped, then nothing to do
         ensure
-          @command_pipe.close rescue nil
-          @command_pipe = nil
+          @command_sender_pipe.close rescue nil
+          @command_sender_pipe = nil
         end
       end
 
@@ -80,7 +80,7 @@ module ServerEngine
       end
 
       def _send_command(cmd)
-        @command_pipe.write cmd + "\n"
+        @command_sender_pipe.write cmd + "\n"
       end
     end
   end

--- a/lib/serverengine/command_sender.rb
+++ b/lib/serverengine/command_sender.rb
@@ -53,11 +53,11 @@ module ServerEngine
     module Pipe
       private
       def _stop(graceful)
-        @command_pipe.write graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n"
+        @command_pipe.write(graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n")
       end
 
       def _restart(graceful)
-        @command_pipe.write graceful ? "GRACEFUL_RESTART\n" : "IMMEDIATE_RESTART\n"
+        @command_pipe.write(graceful ? "GRACEFUL_RESTART\n" : "IMMEDIATE_RESTART\n")
       end
 
       def _reload

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -227,6 +227,26 @@ module ServerEngine
       return 0
     end
 
+    def stop(graceful)
+      _stop(graceful)
+    end
+
+    def restart(graceful)
+      _restart(graceful)
+    end
+
+    def reload
+      _reload
+    end
+
+    def detach
+      _detach
+    end
+
+    def dump
+      _dump
+    end
+
     private
 
     def create_server(logger)

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -50,7 +50,7 @@ module ServerEngine
 
       @pid = nil
       @command_pipe = @config.fetch(:command_pipe, nil)
-      @command_sender = @config.fetch(:command_sender, "signal")
+      @command_sender = @config.fetch(:command_sender, ServerEngine.windows? ? "pipe" : "signal")
       if @command_sender == "pipe"
         extend ServerEngine::CommandSender::Pipe
       else

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -139,9 +139,9 @@ module ServerEngine
     def main
       if @daemonize
         if @command_sender == "pipe"
-          inpipe, @command_pipe = IO.pipe
-          @command_pipe.sync = true
-          @command_pipe.binmode
+          inpipe, @command_sender_pipe = IO.pipe
+          @command_sender_pipe.sync = true
+          @command_sender_pipe.binmode
         end
 
         if ServerEngine.windows?
@@ -182,7 +182,7 @@ module ServerEngine
         begin
           rpipe.close
           if @command_sender == "pipe"
-            @command_pipe.close
+            @command_sender_pipe.close
           end
 
           Process.setsid

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -38,6 +38,14 @@ module ServerEngine
       super(worker_module, load_config_proc, &block)
 
       @reload_signal = @config[:worker_reload_signal]
+      @pm.command_sender = @command_sender
+    end
+
+    def stop(stop_graceful)
+      if @command_sender == "pipe"
+        @pm.command_pipe.write stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n"
+      end
+      super
     end
 
     def run

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -43,7 +43,7 @@ module ServerEngine
 
     def stop(stop_graceful)
       if @command_sender == "pipe"
-        @pm.command_pipe.write stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n"
+        @pm.command_pipe.write(stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n")
       end
       super
     end

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -43,7 +43,7 @@ module ServerEngine
 
     def stop(stop_graceful)
       if @command_sender == "pipe"
-        @pm.command_pipe.write(stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n")
+        @pm.command_sender_pipe.write(stop_graceful ? "GRACEFUL_STOP\n" : "IMMEDIATE_STOP\n")
       end
       super
     end

--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -51,8 +51,6 @@ module ServerEngine
         raise ArgumentError, "unexpected :on_heartbeat_error option (expected Proc, true or false but got #{op.class})"
       end
 
-      @command_sender = config.fetch(:command_sender, "signal")
-
       configure(config)
 
       @closed = false

--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -70,7 +70,7 @@ module ServerEngine
     attr_reader :enable_heartbeat, :auto_heartbeat
 
     attr_accessor :command_sender
-    attr_reader :command_pipe
+    attr_reader :command_sender_pipe
 
     CONFIG_PARAMS = {
       heartbeat_interval: 1,
@@ -165,9 +165,9 @@ module ServerEngine
         end
 
         if @command_sender == "pipe"
-          inpipe, @command_pipe = IO.pipe
-          @command_pipe.sync = true
-          @command_pipe.binmode
+          inpipe, @command_sender_pipe = IO.pipe
+          @command_sender_pipe.sync = true
+          @command_sender_pipe.binmode
           options[:in] = inpipe
         end
         pid = Process.spawn(env, *args, options)

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -32,6 +32,7 @@ module ServerEngine
       @log_stdout = false if logdev_from_config(@config) == STDOUT
       @log_stderr = false if logdev_from_config(@config) == STDERR
 
+      @command_sender = @config.fetch(:command_sender, "signal")
       @command_pipe = @config.fetch(:command_pipe, nil)
     end
 

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -32,7 +32,7 @@ module ServerEngine
       @log_stdout = false if logdev_from_config(@config) == STDOUT
       @log_stderr = false if logdev_from_config(@config) == STDERR
 
-      @command_sender = @config.fetch(:command_sender, "signal")
+      @command_sender = @config.fetch(:command_sender, ServerEngine.windows? ? "pipe" : "signal")
       @command_pipe = @config.fetch(:command_pipe, nil)
     end
 

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -47,7 +47,7 @@ module ServerEngine
 
       @command_pipe = @config.fetch(:command_pipe, nil)
 
-      if @config.fetch(:command_sender, "signal") == "pipe"
+      if @config.fetch(:command_sender, ServerEngine.windows? ? "pipe" : "signal") == "pipe"
         extend CommandSender::Pipe
       else
         extend CommandSender::Signal

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -227,7 +227,7 @@ module ServerEngine
 
     def start_server
       if @command_sender == "pipe"
-        inpipe, @command_pipe = IO.pipe
+        inpipe, @command_sender_pipe = IO.pipe
       end
 
       unless ServerEngine.windows?
@@ -238,7 +238,7 @@ module ServerEngine
           m = @pm.fork do
             $0 = @server_process_name if @server_process_name
             if @command_sender == "pipe"
-              @command_pipe.close
+              @command_sender_pipe.close
               s.instance_variable_set(:@command_pipe, inpipe)
             end
             s.install_signal_handlers

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -110,7 +110,7 @@ module ServerEngine
         # nothing to do
       ensure
         if @command_pipe
-          @command_pipe.close
+          @command_pipe.close rescue nil
           @command_pipe = nil
         end
       end

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -255,7 +255,7 @@ module ServerEngine
         ensure
           s.after_start
         end
-      else
+      else # if ServerEngine.windows?
         inpipe, @command_pipe = IO.pipe
         @last_start_time = Time.now
         m = @pm.spawn(*Array(config[:windows_daemon_cmdline]), in: inpipe)

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -103,30 +103,16 @@ module ServerEngine
       @server = @create_server_proc.call(@load_config_proc, logger)
     end
 
-    def stop_internal(stop_graceful)
-      begin
-        _stop(stop_graceful)
-      rescue Errno::EPIPE
-        # nothing to do
-      ensure
-        if @command_pipe
-          @command_pipe.close rescue nil
-          @command_pipe = nil
-        end
-      end
-    end
-    private :stop_internal
-
     def stop(stop_graceful)
       @stop = true
-      stop_internal(stop_graceful)
+      _stop(stop_graceful)
     end
 
     def restart(stop_graceful)
       reload_config
       @logger.reopen! if @logger
       if @restart_server_process
-        stop_internal(stop_graceful)
+        _stop(stop_graceful)
       else
         _restart(stop_graceful)
       end

--- a/spec/daemon_logger_spec.rb
+++ b/spec/daemon_logger_spec.rb
@@ -112,29 +112,27 @@ describe ServerEngine::DaemonLogger do
     lambda { subject.level = 'unknown' }.should raise_error(ArgumentError)
   end
 
-  unless ServerEngine.windows?
-    it 'rotation' do
-      log = DaemonLogger.new("tmp/se1.log", level: 'trace', log_rotate_age: 3, log_rotate_size: 10000)
-      # 100 bytes
-      log.warn "test1"*20
-      File.exist?("tmp/se1.log").should == true
-      File.exist?("tmp/se1.log.0").should == false
+  it 'rotation' do
+    log = DaemonLogger.new("tmp/se1.log", level: 'trace', log_rotate_age: 3, log_rotate_size: 10000)
+    # 100 bytes
+    log.warn "test1"*20
+    File.exist?("tmp/se1.log").should == true
+    File.exist?("tmp/se1.log.0").should == false
 
-      # 10000 bytes
-      100.times { log.warn "test2"*20 }
-      File.exist?("tmp/se1.log").should == true
-      File.exist?("tmp/se1.log.0").should == true
-      File.read("tmp/se1.log.0") =~ /test2$/
+    # 10000 bytes
+    100.times { log.warn "test2"*20 }
+    File.exist?("tmp/se1.log").should == true
+    File.exist?("tmp/se1.log.0").should == true
+    File.read("tmp/se1.log.0") =~ /test2$/
 
-      # 10000 bytes
-      100.times { log.warn "test3"*20 }
-      File.exist?("tmp/se1.log").should == true
-      File.exist?("tmp/se1.log.1").should == true
-      File.exist?("tmp/se1.log.2").should == false
+    # 10000 bytes
+    100.times { log.warn "test3"*20 }
+    File.exist?("tmp/se1.log").should == true
+    File.exist?("tmp/se1.log.1").should == true
+    File.exist?("tmp/se1.log.2").should == false
 
-      log.warn "test4"*20
-      File.read("tmp/se1.log.0") =~ /test5$/
-    end
+    log.warn "test4"*20
+    File.read("tmp/se1.log.0") =~ /test5$/
   end
 
   it 'IO logger' do
@@ -147,28 +145,26 @@ describe ServerEngine::DaemonLogger do
     log.reopen!
   end
 
-  unless ServerEngine.windows?
-    it 'inter-process locking on rotation' do
-      log = DaemonLogger.new("tmp/se1.log", level: 'trace', log_rotate_age: 3, log_rotate_size: 10)
-      r, w = IO.pipe
-      $stderr = w # To capture #warn output in DaemonLogger
-      pid1 = Process.fork do
-        10.times do
-          log.info '0' * 15
-        end
+  it 'inter-process locking on rotation' do
+    log = DaemonLogger.new("tmp/se1.log", level: 'trace', log_rotate_age: 3, log_rotate_size: 10)
+    r, w = IO.pipe
+    $stderr = w # To capture #warn output in DaemonLogger
+    pid1 = Process.fork do
+      10.times do
+        log.info '0' * 15
       end
-      pid2 = Process.fork do
-        10.times do
-          log.info '0' * 15
-        end
-      end
-      Process.waitpid pid1
-      Process.waitpid pid2
-      w.close
-      stderr = r.read
-      r.close
-      $stderr = STDERR
-      stderr.should_not =~ /(log shifting failed|log writing failed|log rotation inter-process lock failed)/
     end
+    pid2 = Process.fork do
+      10.times do
+        log.info '0' * 15
+      end
+    end
+    Process.waitpid pid1
+    Process.waitpid pid2
+    w.close
+    stderr = r.read
+    r.close
+    $stderr = STDERR
+    stderr.should_not =~ /(log shifting failed|log writing failed|log rotation inter-process lock failed)/
   end
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -2,52 +2,53 @@
 describe ServerEngine::Daemon do
   include_context 'test server and worker'
 
-  unless ServerEngine.windows?
-    it 'run and graceful stop by signal' do
-      dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
-      dm.main
+  it 'run and graceful stop by signal' do
+    pending "not supported signal base commands on Windows" if ServerEngine.windows?
 
-      wait_for_fork
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm.main
 
-      test_state(:server_initialize).should == 1
+    wait_for_fork
 
-      begin
-        dm.stop(true)
-        wait_for_stop
+    test_state(:server_initialize).should == 1
 
-        test_state(:server_stop_graceful).should == 1
-        test_state(:worker_stop).should == 1
-        test_state(:server_after_run).should == 1
-      ensure
-        dm.stop(false) rescue nil
-      end
+    begin
+      dm.stop(true)
+      wait_for_stop
+
+      test_state(:server_stop_graceful).should == 1
+      test_state(:worker_stop).should == 1
+      test_state(:server_after_run).should == 1
+    ensure
+      dm.stop(false) rescue nil
     end
+  end
 
-    it 'signals' do
-      dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
-      dm.main
+  it 'signals' do
+    pending "not supported signal base commands on Windows" if ServerEngine.windows?
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm.main
 
-      wait_for_fork
+    wait_for_fork
 
-      begin
-        dm.reload
-        wait_for_stop
-        test_state(:server_reload).should == 1
+    begin
+      dm.reload
+      wait_for_stop
+      test_state(:server_reload).should == 1
 
-        dm.restart(true)
-        wait_for_stop
-        test_state(:server_restart_graceful).should == 1
+      dm.restart(true)
+      wait_for_stop
+      test_state(:server_restart_graceful).should == 1
 
-        dm.restart(false)
-        wait_for_stop
-        test_state(:server_restart_immediate).should == 1
+      dm.restart(false)
+      wait_for_stop
+      test_state(:server_restart_immediate).should == 1
 
-        dm.stop(false)
-        wait_for_stop
-        test_state(:server_stop_immediate).should == 1
-      ensure
-        dm.stop(true) rescue nil
-      end
+      dm.stop(false)
+      wait_for_stop
+      test_state(:server_stop_immediate).should == 1
+    ensure
+      dm.stop(true) rescue nil
     end
   end
 

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -5,7 +5,7 @@ describe ServerEngine::Daemon do
   it 'run and graceful stop by signal' do
     pending "not supported signal base commands on Windows" if ServerEngine.windows?
 
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", command_sender: "signal")
     dm.main
 
     wait_for_fork
@@ -26,7 +26,7 @@ describe ServerEngine::Daemon do
 
   it 'signals' do
     pending "not supported signal base commands on Windows" if ServerEngine.windows?
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", command_sender: "signal")
     dm.main
 
     wait_for_fork

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -2,54 +2,99 @@
 describe ServerEngine::Daemon do
   include_context 'test server and worker'
 
-  it 'run and graceful stop' do
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline)
+  unless ServerEngine.windows?
+    it 'run and graceful stop by signal' do
+      dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+      dm.main
+
+      wait_for_fork
+
+      test_state(:server_initialize).should == 1
+
+      begin
+        dm.stop(true)
+        wait_for_stop
+
+        test_state(:server_stop_graceful).should == 1
+        test_state(:worker_stop).should == 1
+        test_state(:server_after_run).should == 1
+      ensure
+        dm.stop(false) rescue nil
+      end
+    end
+
+    it 'signals' do
+      dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+      dm.main
+
+      wait_for_fork
+
+      begin
+        dm.reload
+        wait_for_stop
+        test_state(:server_reload).should == 1
+
+        dm.restart(true)
+        wait_for_stop
+        test_state(:server_restart_graceful).should == 1
+
+        dm.restart(false)
+        wait_for_stop
+        test_state(:server_restart_immediate).should == 1
+
+        dm.stop(false)
+        wait_for_stop
+        test_state(:server_stop_immediate).should == 1
+      ensure
+        dm.stop(true) rescue nil
+      end
+    end
+  end
+
+  it 'run and graceful stop by pipe' do
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline, command_sender: "pipe")
     dm.main
 
-    pid = File.read('tmp/pid').to_i
     wait_for_fork
 
     test_state(:server_initialize).should == 1
 
-    if ServerEngine.windows?
-      Process.kill(:KILL, pid)
-    else
-      Process.kill(:TERM, pid)
-    end
-    wait_for_stop
+    begin
+      dm.stop(true)
+      wait_for_stop
 
-    test_state(:server_stop_graceful).should == 1
-    test_state(:worker_stop).should == 1
-    test_state(:server_after_run).should == 1
+      test_state(:server_stop_graceful).should == 1
+      test_state(:worker_stop).should == 1
+      test_state(:server_after_run).should == 1
+    ensure
+      dm.stop(false) rescue nil
+    end
   end
 
-  it 'signals' do
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline)
+  it 'recieve commands from pipe' do
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline, command_sender: "pipe")
     dm.main
 
-    pid = File.read('tmp/pid').to_i
     wait_for_fork
 
-    unless ServerEngine.windows?
-      Process.kill(:USR2, pid)
+    begin
+      dm.reload
       wait_for_stop
       test_state(:server_reload).should == 1
 
-      Process.kill(:USR1, pid)
+      dm.restart(true)
       wait_for_stop
       test_state(:server_restart_graceful).should == 1
 
-      Process.kill(:HUP, pid)
+      dm.restart(false)
       wait_for_stop
       test_state(:server_restart_immediate).should == 1
 
-      Process.kill(:QUIT, pid)
+      dm.stop(false)
       wait_for_stop
       test_state(:server_stop_immediate).should == 1
-    else
-      Process.kill(:KILL, pid)
-      wait_for_stop
+    ensure
+      dm.stop(true) rescue nil
     end
   end
 end
-

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -3,15 +3,19 @@ describe ServerEngine::Daemon do
   include_context 'test server and worker'
 
   it 'run and graceful stop' do
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline)
     dm.main
-
-    test_state(:server_initialize).should == 1
 
     pid = File.read('tmp/pid').to_i
     wait_for_fork
 
-    Process.kill(:TERM, pid)
+    test_state(:server_initialize).should == 1
+
+    if ServerEngine.windows?
+      Process.kill(:KILL, pid)
+    else
+      Process.kill(:TERM, pid)
+    end
     wait_for_stop
 
     test_state(:server_stop_graceful).should == 1
@@ -20,27 +24,32 @@ describe ServerEngine::Daemon do
   end
 
   it 'signals' do
-    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid")
+    dm = Daemon.new(TestServer, TestWorker, daemonize: true, pid_path: "tmp/pid", windows_daemon_cmdline: windows_daemon_cmdline)
     dm.main
 
     pid = File.read('tmp/pid').to_i
     wait_for_fork
 
-    Process.kill(:USR2, pid)
-    wait_for_stop
-    test_state(:server_reload).should == 1
+    unless ServerEngine.windows?
+      Process.kill(:USR2, pid)
+      wait_for_stop
+      test_state(:server_reload).should == 1
 
-    Process.kill(:USR1, pid)
-    wait_for_stop
-    test_state(:server_restart_graceful).should == 1
+      Process.kill(:USR1, pid)
+      wait_for_stop
+      test_state(:server_restart_graceful).should == 1
 
-    Process.kill(:HUP, pid)
-    wait_for_stop
-    test_state(:server_restart_immediate).should == 1
+      Process.kill(:HUP, pid)
+      wait_for_stop
+      test_state(:server_restart_immediate).should == 1
 
-    Process.kill(:QUIT, pid)
-    wait_for_stop
-    test_state(:server_stop_immediate).should == 1
+      Process.kill(:QUIT, pid)
+      wait_for_stop
+      test_state(:server_stop_immediate).should == 1
+    else
+      Process.kill(:KILL, pid)
+      wait_for_stop
+    end
   end
 end
 

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -1,8 +1,10 @@
 
-describe ServerEngine::MultiWorkerServer do
-  include_context 'test server and worker'
+[ServerEngine::MultiThreadServer, ServerEngine::MultiProcessServer].each do |impl_class|
+  # MultiProcessServer uses fork(2) internally, then it doesn't support Windows.
+  next if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
-  [MultiThreadServer, MultiProcessServer].each do |impl_class|
+  describe impl_class do
+    include_context 'test server and worker'
 
     it 'scale up' do
       config = {:workers => 2}

--- a/spec/server_worker_context.rb
+++ b/spec/server_worker_context.rb
@@ -15,7 +15,8 @@ require "rspec"
 $state_file_mutex = Mutex.new # TODO
 require "server_worker_context"
 include ServerEngine
-Daemon.run_server(TestServer, TestWorker)
+command_pipe = STDIN.dup
+Daemon.run_server(TestServer, TestWorker, command_pipe: command_pipe)
       end
     end
   end

--- a/spec/server_worker_context.rb
+++ b/spec/server_worker_context.rb
@@ -7,6 +7,26 @@ def reset_test_state
   FileUtils.rm_f 'tmp/state.yml'
   FileUtils.touch 'tmp/state.yml'
   $state_file_mutex = Mutex.new
+  if ServerEngine.windows?
+    open("tmp/daemon.rb", "w") do |f|
+      f.puts <<-end
+require "serverengine"
+require "rspec"
+$state_file_mutex = Mutex.new # TODO
+require "server_worker_context"
+include ServerEngine
+Daemon.run_server(TestServer, TestWorker)
+      end
+    end
+  end
+end
+
+def windows_daemon_cmdline
+  if ServerEngine.windows?
+    [ServerEngine.ruby_bin_path, '-I', File.dirname(__FILE__), 'tmp/daemon.rb']
+  else
+    nil
+  end
 end
 
 def incr_test_state(key)

--- a/spec/signal_thread_spec.rb
+++ b/spec/signal_thread_spec.rb
@@ -6,84 +6,89 @@ describe ServerEngine::SignalThread do
     t.join
   end
 
-  it 'call handler' do
-    n = 0
+  unless ServerEngine.windows?
+    it 'call handler' do
+      n = 0
 
-    t = SignalThread.new do |st|
-      st.trap('CONT') { n += 1 }
+      t = SignalThread.new do |st|
+        st.trap('CONT') { n += 1 }
+      end
+
+      Process.kill('CONT', Process.pid)
+      sleep 0.5
+
+      t.stop.join
+
+      n.should == 1
     end
 
-    Process.kill('CONT', Process.pid)
-    sleep 0.5
+    it 'SIG_IGN' do
+      # IGNORE signal handler has possible race condition in Ruby 2.1
+      # https://bugs.ruby-lang.org/issues/9835
+      # That's why ignore this test in Ruby2.1
+      if RUBY_VERSION >= '2.2'
+        t = SignalThread.new do |st|
+          st.trap('QUIT', 'SIG_IGN')
+        end
 
-    t.stop.join
+        Process.kill('QUIT', Process.pid)
 
-    n.should == 1
-  end
+        t.stop.join
+      end
+    end
 
-  it 'SIG_IGN' do
-    # IGNORE signal handler has possible race condition in Ruby 2.1
-    # https://bugs.ruby-lang.org/issues/9835
-    # That's why ignore this test in Ruby2.1
-    if RUBY_VERSION >= '2.2'
-      t = SignalThread.new do |st|
-        st.trap('QUIT', 'SIG_IGN')
+    it 'signal in handler' do
+      n = 0
+
+      SignalThread.new do |st|
+        st.trap('QUIT') do
+          if n < 3
+            Process.kill('QUIT', Process.pid)
+            n += 1
+          end
+        end
       end
 
       Process.kill('QUIT', Process.pid)
+      sleep 0.5
 
-      t.stop.join
+      n.should == 3
     end
-  end
 
-  it 'signal in handler' do
-    n = 0
-
-    SignalThread.new do |st|
-      st.trap('QUIT') do
-        if n < 3
-          Process.kill('QUIT', Process.pid)
-          n += 1
-        end
+    it 'stop in handler' do
+      t = SignalThread.new do |st|
+        st.trap('QUIT') { st.stop }
       end
-    end
 
-    Process.kill('QUIT', Process.pid)
-    sleep 0.5
+      Process.kill('QUIT', Process.pid)
+      sleep 0.5
 
-    n.should == 3
-  end
-
-  it 'stop in handler' do
-    t = SignalThread.new do |st|
-      st.trap('QUIT') { st.stop }
-    end
-
-    Process.kill('QUIT', Process.pid)
-    sleep 0.5
-
-    t.join
-  end
-
-  it 'should not deadlock' do
-    n = 0
-
-    SignalThread.new do |st|
-      st.trap('CONT') { n += 1 }
-    end
-
-    (1..10).map {
-      Thread.new do
-        10.times {
-          Process.kill('CONT', Process.pid)
-        }
-      end
-    }.each { |t|
       t.join
-    }
+    end
 
-    # result won't be 100 because of kernel limitation
-    n.should > 0
+    it 'should not deadlock' do
+      n = 0
+
+      SignalThread.new do |st|
+        st.trap('CONT') { n += 1 }
+      end
+
+      (1..10).map {
+        Thread.new do
+          10.times {
+            Process.kill('CONT', Process.pid)
+          }
+        end
+      }.each { |t|
+        t.join
+      }
+
+      # give chance to run the signal thread
+      sleep 0.1
+
+      # result won't be 100 because of kernel limitation
+      n.should > 0
+    end
   end
 end
 

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -10,6 +10,8 @@ describe ServerEngine::Supervisor do
   end
 
   def start_daemon(config={})
+    config = config.dup
+    config[:windows_daemon_cmdline] = windows_daemon_cmdline
     daemon = Daemon.new(nil, TestWorker, config)
     t = Thread.new { daemon.main }
 

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -5,7 +5,6 @@ describe ServerEngine::Supervisor do
   def start_supervisor(worker = nil, config={})
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_supervisor_cmdline(nil, worker, config)
-      config[:command_sender] = "pipe"
     end
     sv = Supervisor.new(TestServer, worker || TestWorker, config)
     t = Thread.new { sv.main }
@@ -16,7 +15,6 @@ describe ServerEngine::Supervisor do
   def start_daemon(config={})
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_daemon_cmdline
-      config[:command_sender] = "pipe"
     end
     daemon = Daemon.new(nil, TestWorker, config)
     t = Thread.new { daemon.main }

--- a/spec/supervisor_spec.rb
+++ b/spec/supervisor_spec.rb
@@ -2,7 +2,7 @@
 describe ServerEngine::Supervisor do
   include_context 'test server and worker'
 
-  def start_supervisor(worker = nil, config={})
+  def start_supervisor(worker = nil, **config)
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_supervisor_cmdline(nil, worker, config)
     end
@@ -12,7 +12,7 @@ describe ServerEngine::Supervisor do
     return sv, t
   end
 
-  def start_daemon(config={})
+  def start_daemon(**config)
     if ServerEngine.windows?
       config[:windows_daemon_cmdline] = windows_daemon_cmdline
     end
@@ -72,105 +72,135 @@ describe ServerEngine::Supervisor do
     end
   end
 
-  it 'start and graceful stop' do
-    sv, t = start_supervisor
+  ['signal', 'pipe'].each do |sender|
+    context "when using #{sender} as command_sender" do
 
-    begin
-      wait_for_fork
+      it 'start and graceful stop' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
 
-      test_state(:server_before_run).should == 1
-      test_state(:server_after_start).should == 1  # parent
-    ensure
-      sv.stop(true)
-      t.join
+        sv, t = start_supervisor(command_sender: sender)
+
+        begin
+          wait_for_fork
+
+          test_state(:server_before_run).should == 1
+          test_state(:server_after_start).should == 1  # parent
+        ensure
+          sv.stop(true)
+          t.join
+        end
+
+        test_state(:server_stop).should == 1
+        test_state(:server_stop_graceful).should == 1
+        test_state(:server_restart).should == 0
+
+        test_state(:server_after_run).should == 1
+        test_state(:server_after_start).should == 1
+      end
+
+      it 'immediate stop' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        sv, t = start_supervisor(command_sender: sender)
+
+        begin
+          wait_for_fork
+        ensure
+          sv.stop(false)
+          t.join
+        end
+
+        test_state(:server_stop).should == 1
+        test_state(:server_stop_immediate).should == 1
+        test_state(:server_after_run).should == 1
+        test_state(:server_after_start).should == 1
+      end
+
+      it 'graceful restart' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        sv, t = start_supervisor(command_sender: sender)
+
+        begin
+          wait_for_fork
+
+          sv.restart(true)
+          wait_for_stop
+
+        ensure
+          sv.stop(true)
+          t.join
+        end
+
+        test_state(:server_stop).should == 1
+        test_state(:server_restart_graceful).should == 1
+
+        test_state(:server_before_run).should == 1
+        test_state(:server_after_run).should == 1
+        test_state(:server_after_start).should == 1
+      end
+
+      it 'immediate restart' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        sv, t = start_supervisor(command_sender: sender)
+
+        begin
+          wait_for_fork
+
+          sv.restart(false)
+          wait_for_stop
+
+        ensure
+          sv.stop(true)
+          t.join
+        end
+
+        test_state(:server_stop).should == 1
+        test_state(:server_restart_immediate).should == 1
+
+        test_state(:server_before_run).should == 1
+        test_state(:server_after_run).should == 1
+        test_state(:server_after_start).should == 1
+      end
+
+      it 'reload' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        sv, t = start_supervisor(command_sender: sender)
+
+        begin
+          wait_for_fork
+
+          sv.reload
+
+        ensure
+          sv.stop(true)
+          t.join
+        end
+
+        test_state(:server_stop).should == 1
+        test_state(:server_reload).should == 1
+      end
+
+      # TODO detach
+
+      it 'auto restart in limited ratio' do
+        pending 'not supported on Windows' if ServerEngine.windows? && sender == 'signal'
+
+        sv, t = start_supervisor(RunErrorWorker, server_restart_wait: 1, command_sender: sender)
+
+        begin
+          sleep 2.2
+        ensure
+          sv.stop(true)
+          t.join
+        end
+
+        test_state(:worker_run).should == 3
+      end
     end
-
-    test_state(:server_stop).should == 1
-    test_state(:server_stop_graceful).should == 1
-    test_state(:server_restart).should == 0
-
-    test_state(:server_after_run).should == 1
-    test_state(:server_after_start).should == 1
   end
-
-  it 'immediate stop' do
-    sv, t = start_supervisor
-
-    begin
-      wait_for_fork
-    ensure
-      sv.stop(false)
-      t.join
-    end
-
-    test_state(:server_stop).should == 1
-    test_state(:server_stop_immediate).should == 1
-    test_state(:server_after_run).should == 1
-    test_state(:server_after_start).should == 1
-  end
-
-  it 'graceful restart' do
-    sv, t = start_supervisor
-
-    begin
-      wait_for_fork
-
-      sv.restart(true)
-      wait_for_stop
-
-    ensure
-      sv.stop(true)
-      t.join
-    end
-
-    test_state(:server_stop).should == 1
-    test_state(:server_restart_graceful).should == 1
-
-    test_state(:server_before_run).should == 1
-    test_state(:server_after_run).should == 1
-    test_state(:server_after_start).should == 1
-  end
-
-  it 'immediate restart' do
-    sv, t = start_supervisor
-
-    begin
-      wait_for_fork
-
-      sv.restart(false)
-      wait_for_stop
-
-    ensure
-      sv.stop(true)
-      t.join
-    end
-
-    test_state(:server_stop).should == 1
-    test_state(:server_restart_immediate).should == 1
-
-    test_state(:server_before_run).should == 1
-    test_state(:server_after_run).should == 1
-    test_state(:server_after_start).should == 1
-  end
-
-  it 'reload' do
-    sv, t = start_supervisor
-
-    begin
-      wait_for_fork
-
-      sv.reload
-
-    ensure
-      sv.stop(true)
-      t.join
-    end
-
-    test_state(:server_stop).should == 1
-    test_state(:server_reload).should == 1
-  end
-
-  # TODO detach
 
   module InitializeErrorServer
     def initialize
@@ -182,18 +212,4 @@ describe ServerEngine::Supervisor do
     sv = Supervisor.new(InitializeErrorServer, TestWorker)
     lambda { sv.main }.should raise_error(StandardError)
   end
-
-  it 'auto restart in limited ratio' do
-    sv, t = start_supervisor(RunErrorWorker, server_restart_wait: 1)
-
-    begin
-      sleep 2.2
-    ensure
-      sv.stop(true)
-      t.join
-    end
-
-    test_state(:worker_run).should == 3
-  end
-
 end


### PR DESCRIPTION
Windows does not support interprocess signals.
Ruby emulates it a little, but not enough.
Therefore, ServerEngine should use another mechanism to send commands.
This patch implements piped command interface.
see also https://github.com/fluent/fluentd/issues/1084