### PR TITLE
Use `windows-pr` for `GetModuleFileName`

### DIFF
--- a/lib/serverengine.rb
+++ b/lib/serverengine.rb
@@ -54,8 +54,9 @@ module ServerEngine
 
   def self.ruby_bin_path
     if ServerEngine.windows?
+      require 'windows/library'
       ruby_path = "\0" * 256
-      GetModuleFileName.call(0, ruby_path, 256)
+      Windows::Library.GetModuleFileName.call(0, ruby_path, 256)
       return ruby_path.rstrip.gsub(/\\/, '/')
     else
       return File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"]) + RbConfig::CONFIG["EXEEXT"]

--- a/lib/serverengine.rb
+++ b/lib/serverengine.rb
@@ -56,7 +56,7 @@ module ServerEngine
     if ServerEngine.windows?
       require 'windows/library'
       ruby_path = "\0" * 256
-      Windows::Library.GetModuleFileName.call(0, ruby_path, 256)
+      Windows::Library::GetModuleFileName.call(0, ruby_path, 256)
       return ruby_path.rstrip.gsub(/\\/, '/')
     else
       return File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["RUBY_INSTALL_NAME"]) + RbConfig::CONFIG["EXEEXT"]

--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -23,4 +23,8 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake", [">= 0.9.2"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]
+
+  if /mswin|mingw/ =~ RUBY_PLATFORM
+    gem.add_runtime_dependency("windows-pr", ["~> 1.2.5"])
+  end
 end


### PR DESCRIPTION
There is no implementation for `GetModuleFileName` in `SeverEngine.ruby_bin_path`.
Use `windows-pr` gem for it, like fluentd.
This pull-req is required by tests of #50.