### PR TITLE
fix not to share process manager instance to break tight coupling

### DIFF
--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -309,18 +309,18 @@ module ServerEngine
       def initialize(pid, opts={})
         @pid = pid
 
-        @enable_heartbeat = kwargs[:enable_heartbeat]
-        @heartbeat_timeout = kwargs[:heartbeat_timeout]
+        @enable_heartbeat = opts[:enable_heartbeat]
+        @heartbeat_timeout = opts[:heartbeat_timeout]
 
-        @graceful_kill_signal   = kwargs[:graceful_kill_signal]
-        @graceful_kill_timeout  = kwargs[:graceful_kill_timeout]
-        @graceful_kill_interval = kwargs[:graceful_kill_interval]
-        @graceful_kill_interval_increment = kwargs[:graceful_kill_interval_increment]
+        @graceful_kill_signal   = opts[:graceful_kill_signal]
+        @graceful_kill_timeout  = opts[:graceful_kill_timeout]
+        @graceful_kill_interval = opts[:graceful_kill_interval]
+        @graceful_kill_interval_increment = opts[:graceful_kill_interval_increment]
 
-        @immediate_kill_signal   = kwargs[:immediate_kill_signal]
-        @immediate_kill_timeout  = kwargs[:immediate_kill_timeout]
-        @immediate_kill_interval = kwargs[:immediate_kill_interval]
-        @immediate_kill_interval_increment = kwargs[:immediate_kill_interval_increment]
+        @immediate_kill_signal   = opts[:immediate_kill_signal]
+        @immediate_kill_timeout  = opts[:immediate_kill_timeout]
+        @immediate_kill_interval = opts[:immediate_kill_interval]
+        @immediate_kill_interval_increment = opts[:immediate_kill_interval_increment]
 
         @error = false
         @last_heartbeat_time = Time.now


### PR DESCRIPTION
Currently some class instances holds the instance of process manager, only for passing just some configuration parameters to these classes.
It makes code unreadable and hard to maintain.

This pull request is to change such code as roughly coupled, by passing just parameters, not process manager instance.