### PR TITLE
Separate signals from daemon

### DIFF
--- a/lib/serverengine/command_sender.rb
+++ b/lib/serverengine/command_sender.rb
@@ -15,7 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-require 'serverengine/daemon'
+require 'serverengine/signals'
 
 module ServerEngine
   module CommandSender
@@ -23,23 +23,23 @@ module ServerEngine
     module Signal
       private
       def _stop(graceful)
-        _send_signal(!ServerEngine.windows? && graceful ? Daemon::Signals::GRACEFUL_STOP : Daemon::Signals::IMMEDIATE_STOP)
+        _send_signal(!ServerEngine.windows? && graceful ? Signals::GRACEFUL_STOP : Signals::IMMEDIATE_STOP)
       end
 
       def _restart(graceful)
-        _send_signal(graceful ? Daemon::Signals::GRACEFUL_RESTART : Daemon::Signals::IMMEDIATE_RESTART)
+        _send_signal(graceful ? Signals::GRACEFUL_RESTART : Signals::IMMEDIATE_RESTART)
       end
 
       def _reload
-        _send_signal(Daemon::Signals::RELOAD)
+        _send_signal(Signals::RELOAD)
       end
 
       def _detach
-        _send_signal(Daemon::Signals::DETACH)
+        _send_signal(Signals::DETACH)
       end
 
       def _dump
-        _send_signal(Daemon::Signals::DUMP)
+        _send_signal(Signals::DUMP)
       end
 
       def _send_signal(sig)

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -63,16 +63,6 @@ module ServerEngine
     # server is available when run() is called. It is a Supervisor instance if supervisor is set to true. Otherwise a Server instance.
     attr_reader :server
 
-    module Signals
-      GRACEFUL_STOP = :TERM
-      IMMEDIATE_STOP = ServerEngine::windows? ? :KILL : :QUIT
-      GRACEFUL_RESTART = :USR1
-      IMMEDIATE_RESTART = :HUP
-      RELOAD = :USR2
-      DETACH = :INT
-      DUMP = :CONT
-    end
-
     def self.get_etc_passwd(user)
       if user.to_i.to_s == user
         Etc.getpwuid(user.to_i)

--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -15,6 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'serverengine/signals'
 require 'serverengine/daemon'
 require 'serverengine/process_manager'
 require 'serverengine/multi_worker_server'
@@ -25,8 +26,8 @@ module ServerEngine
     def initialize(worker_module, load_config_proc={}, &block)
       @pm = ProcessManager.new(
         auto_tick: false,
-        graceful_kill_signal: Daemon::Signals::GRACEFUL_STOP,
-        immediate_kill_signal: Daemon::Signals::IMMEDIATE_STOP,
+        graceful_kill_signal: Signals::GRACEFUL_STOP,
+        immediate_kill_signal: Signals::IMMEDIATE_STOP,
         enable_heartbeat: true,
         auto_heartbeat: true,
         on_heartbeat_error: Proc.new do
@@ -112,7 +113,7 @@ module ServerEngine
       end
 
       def send_reload
-        @pmon.send_signal(Daemon::Signals::RELOAD) if @pmon
+        @pmon.send_signal(Signals::RELOAD) if @pmon
         nil
       end
 

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -15,7 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-require 'serverengine/daemon'
+require 'serverengine/signals'
 require 'serverengine/process_manager'
 require 'serverengine/multi_worker_server'
 
@@ -26,15 +26,15 @@ module ServerEngine
       if ServerEngine.windows?
         @pm = ProcessManager.new(
           auto_tick: false,
-          graceful_kill_signal: Daemon::Signals::GRACEFUL_STOP,
+          graceful_kill_signal: Signals::GRACEFUL_STOP,
           immediate_kill_signal: false,
           enable_heartbeat: false,
         )
       else
         @pm = ProcessManager.new(
           auto_tick: false,
-          graceful_kill_signal: Daemon::Signals::GRACEFUL_STOP,
-          immediate_kill_signal: Daemon::Signals::IMMEDIATE_STOP,
+          graceful_kill_signal: Signals::GRACEFUL_STOP,
+          immediate_kill_signal: Signals::IMMEDIATE_STOP,
           enable_heartbeat: false,
         )
       end

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -15,7 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-require 'serverengine/signal'
+require 'serverengine/signals'
 require 'serverengine/signal_thread'
 require 'serverengine/worker'
 

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -15,7 +15,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-require 'serverengine/daemon'
+require 'serverengine/signal'
 require 'serverengine/signal_thread'
 require 'serverengine/worker'
 
@@ -94,16 +94,16 @@ module ServerEngine
         end
       else
         SignalThread.new do |st|
-          st.trap(@config[:signal_graceful_stop] || Daemon::Signals::GRACEFUL_STOP) { s.stop(true) }
-          st.trap(@config[:signal_detach] || Daemon::Signals::DETACH) { s.stop(true) }
+          st.trap(@config[:signal_graceful_stop] || Signals::GRACEFUL_STOP) { s.stop(true) }
+          st.trap(@config[:signal_detach] || Signals::DETACH) { s.stop(true) }
           # Here disables signals excepting GRACEFUL_STOP == :SIGTERM because
           # only SIGTERM is available on all version of Windows.
           unless ServerEngine.windows?
-            st.trap(@config[:signal_immediate_stop] || Daemon::Signals::IMMEDIATE_STOP) { s.stop(false) }
-            st.trap(@config[:signal_graceful_restart] || Daemon::Signals::GRACEFUL_RESTART) { s.restart(true) }
-            st.trap(@config[:signal_immediate_restart] || Daemon::Signals::IMMEDIATE_RESTART) { s.restart(false) }
-            st.trap(@config[:signal_reload] || Daemon::Signals::RELOAD) { s.reload }
-            st.trap(@config[:signal_dump] || Daemon::Signals::DUMP) { Sigdump.dump }
+            st.trap(@config[:signal_immediate_stop] || Signals::IMMEDIATE_STOP) { s.stop(false) }
+            st.trap(@config[:signal_graceful_restart] || Signals::GRACEFUL_RESTART) { s.restart(true) }
+            st.trap(@config[:signal_immediate_restart] || Signals::IMMEDIATE_RESTART) { s.restart(false) }
+            st.trap(@config[:signal_reload] || Signals::RELOAD) { s.reload }
+            st.trap(@config[:signal_dump] || Signals::DUMP) { Sigdump.dump }
           end
         end
       end

--- a/lib/serverengine/signals.rb
+++ b/lib/serverengine/signals.rb
@@ -16,6 +16,8 @@
 #    limitations under the License.
 #
 
+require 'serverengine/utils'
+
 module ServerEngine
   module Signals
     GRACEFUL_STOP = :TERM

--- a/lib/serverengine/signals.rb
+++ b/lib/serverengine/signals.rb
@@ -1,0 +1,29 @@
+#
+# ServerEngine
+#
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+module ServerEngine
+  module Signals
+    GRACEFUL_STOP = :TERM
+    IMMEDIATE_STOP = ServerEngine::windows? ? :KILL : :QUIT
+    GRACEFUL_RESTART = :USR1
+    IMMEDIATE_RESTART = :HUP
+    RELOAD = :USR2
+    DETACH = :INT
+    DUMP = :CONT
+  end
+end

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -19,6 +19,7 @@ require 'serverengine/config_loader'
 require 'serverengine/blocking_flag'
 require 'serverengine/process_manager'
 require 'serverengine/command_sender'
+require 'serverengine/signals'
 
 require 'serverengine/embedded_server'
 require 'serverengine/multi_process_server'
@@ -39,8 +40,8 @@ module ServerEngine
 
       @pm = ProcessManager.new(
         auto_tick: false,
-        graceful_kill_signal: Daemon::Signals::GRACEFUL_STOP,
-        immediate_kill_signal: Daemon::Signals::IMMEDIATE_STOP,
+        graceful_kill_signal: Signals::GRACEFUL_STOP,
+        immediate_kill_signal: Signals::IMMEDIATE_STOP,
         enable_heartbeat: true,
         auto_heartbeat: true,
       )
@@ -171,13 +172,13 @@ module ServerEngine
         end
       else
         SignalThread.new do |st|
-          st.trap(Daemon::Signals::GRACEFUL_STOP) { s.stop(true) }
-          st.trap(Daemon::Signals::IMMEDIATE_STOP) { s.stop(false) }
-          st.trap(Daemon::Signals::GRACEFUL_RESTART) { s.restart(true) }
-          st.trap(Daemon::Signals::IMMEDIATE_RESTART) { s.restart(false) }
-          st.trap(Daemon::Signals::RELOAD) { s.reload }
-          st.trap(Daemon::Signals::DETACH) { s.detach(true) }
-          st.trap(Daemon::Signals::DUMP) { Sigdump.dump }
+          st.trap(Signals::GRACEFUL_STOP) { s.stop(true) }
+          st.trap(Signals::IMMEDIATE_STOP) { s.stop(false) }
+          st.trap(Signals::GRACEFUL_RESTART) { s.restart(true) }
+          st.trap(Signals::IMMEDIATE_RESTART) { s.restart(false) }
+          st.trap(Signals::RELOAD) { s.reload }
+          st.trap(Signals::DETACH) { s.detach(true) }
+          st.trap(Signals::DUMP) { Sigdump.dump }
         end
       end
     end

--- a/lib/serverengine/worker.rb
+++ b/lib/serverengine/worker.rb
@@ -15,8 +15,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+require 'serverengine/signals'
 require 'serverengine/signal_thread'
-require 'serverengine/daemon'
 
 module ServerEngine
 
@@ -57,19 +57,19 @@ module ServerEngine
     def install_signal_handlers
       w = self
       SignalThread.new do |st|
-        st.trap(Daemon::Signals::GRACEFUL_STOP) { w.stop }
-        st.trap(Daemon::Signals::IMMEDIATE_STOP, 'SIG_DFL')
+        st.trap(Signals::GRACEFUL_STOP) { w.stop }
+        st.trap(Signals::IMMEDIATE_STOP, 'SIG_DFL')
 
-        st.trap(Daemon::Signals::GRACEFUL_RESTART) { w.stop }
-        st.trap(Daemon::Signals::IMMEDIATE_RESTART, 'SIG_DFL')
+        st.trap(Signals::GRACEFUL_RESTART) { w.stop }
+        st.trap(Signals::IMMEDIATE_RESTART, 'SIG_DFL')
 
-        st.trap(Daemon::Signals::RELOAD) {
+        st.trap(Signals::RELOAD) {
           w.logger.reopen!
           w.reload
         }
-        st.trap(Daemon::Signals::DETACH) { w.stop }
+        st.trap(Signals::DETACH) { w.stop }
 
-        st.trap(Daemon::Signals::DUMP) { Sigdump.dump }
+        st.trap(Signals::DUMP) { Sigdump.dump }
       end
     end
 


### PR DESCRIPTION
This change is based on #56.

Having `Signals` in `Daemon` module makes unhealthy circular file dependencies (e.g., daemon.rb <-> supervisor.rb).
ServerEngine::Daemon is now independent from signal details (because daemon may use pipes), so it's good time to separate Signals from Daemon.

Users might use reference for `ServerEngine::Daemon::Signals`, but I believe that ServerEngine is originally to make users (author of server software) free from such details. So I think there are just few users (or no users) who doing such things.