### PR TITLE
Separate privilege from daemon

### DIFF
--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -19,6 +19,7 @@ require 'serverengine/signals'
 require 'serverengine/daemon'
 require 'serverengine/process_manager'
 require 'serverengine/multi_worker_server'
+require 'serverengine/privilege'
 
 module ServerEngine
 
@@ -75,7 +76,7 @@ module ServerEngine
           $0 = @worker_process_name % [wid] if @worker_process_name
           w.install_signal_handlers
 
-          Daemon.change_privilege(@chuser, @chgroup)
+          Privilege.change(@chuser, @chgroup)
           File.umask(@chumask) if @chumask
 
           ## recreate the logger created at Server#main

--- a/lib/serverengine/privilege.rb
+++ b/lib/serverengine/privilege.rb
@@ -1,0 +1,57 @@
+#
+# ServerEngine
+#
+# Copyright (C) 2012-2013 FURUHASHI Sadayuki
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+require 'etc'
+
+module ServerEngine
+  module Privilege
+    def self.get_etc_passwd(user)
+      if user.to_i.to_s == user
+        Etc.getpwuid(user.to_i)
+      else
+        Etc.getpwnam(user)
+      end
+    end
+
+    def self.get_etc_group(group)
+      if group.to_i.to_s == group
+        Etc.getgrgid(group.to_i)
+      else
+        Etc.getgrnam(group)
+      end
+    end
+
+    def self.change(user, group)
+      if user
+        etc_pw = get_etc_passwd(user)
+        user_groups = [etc_pw.gid]
+        Etc.setgrent
+        Etc.group { |gr| user_groups << gr.gid if gr.mem.include?(etc_pw.name) } # emulate 'id -G'
+
+        Process.groups = Process.groups | user_groups
+        Process::UID.change_privilege(etc_pw.uid)
+      end
+
+      if group
+        etc_group = get_etc_group(group)
+        Process::GID.change_privilege(etc_group.gid)
+      end
+
+      nil
+    end
+  end
+end


### PR DESCRIPTION
This change is based on #56.

Controlling process privileges are originally free from daemon itself, and it's also required by servers with multi processing.
It's better to be separated from daemon.rb to code and file dependency clean.