### PR TITLE
Move util methods to utils

### DIFF
--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -125,7 +125,7 @@ module ServerEngine
         return false unless @pmon
 
         if stat = @pmon.try_join
-          @worker.logger.info "Worker #{@wid} finished#{@stop ? '' : ' unexpectedly'} with #{ProcessManager.format_join_status(stat)}"
+          @worker.logger.info "Worker #{@wid} finished#{@stop ? '' : ' unexpectedly'} with #{ServerEngine.format_join_status(stat)}"
           @pmon = nil
           return false
         else

--- a/lib/serverengine/process_manager.rb
+++ b/lib/serverengine/process_manager.rb
@@ -278,28 +278,6 @@ module ServerEngine
       nil
     end
 
-    def self.format_signal_name(n)
-      Signal.list.each_pair {|k,v|
-        return "SIG#{k}" if n == v
-      }
-      return n
-    end
-
-    def self.format_join_status(code)
-      case code
-      when Process::Status
-        if code.signaled?
-          "signal #{format_signal_name(code.termsig)}"
-        else
-          "status #{code.exitstatus}"
-        end
-      when Exception
-        "exception #{code}"
-      when nil
-        "unknown reason"
-      end
-    end
-
     class AlreadyClosedError < EOFError
     end
 

--- a/lib/serverengine/supervisor.rb
+++ b/lib/serverengine/supervisor.rb
@@ -226,7 +226,7 @@ module ServerEngine
 
     def try_join
       if stat = @pmon.try_join
-        @logger.info "Server finished#{@stop ? '' : ' unexpectedly'} with #{ProcessManager.format_join_status(stat)}"
+        @logger.info "Server finished#{@stop ? '' : ' unexpectedly'} with #{ServerEngine.format_join_status(stat)}"
         @pmon = nil
         return stat
       else

--- a/lib/serverengine/utils.rb
+++ b/lib/serverengine/utils.rb
@@ -32,6 +32,29 @@ module ServerEngine
       }
       nil
     end
+
+    def format_signal_name(n)
+      Signal.list.each_pair {|k,v|
+        return "SIG#{k}" if n == v
+      }
+      return n
+    end
+
+    def format_join_status(code)
+      case code
+      when Process::Status
+        if code.signaled?
+          "signal #{format_signal_name(code.termsig)}"
+        else
+          "status #{code.exitstatus}"
+        end
+      when Exception
+        "exception #{code}"
+      when nil
+        "unknown reason"
+      end
+    end
+
   end
 
   extend ClassMethods


### PR DESCRIPTION
This change is based on #56.

Utility methods like #format_join_status in ProcessManager is almost not related with ProcessManager itself, and be used in some other classes.
So it should be separated from ProcessManager and be shared as utility methods.
