### PR TITLE
v2.0.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,12 @@
+2016-08-22 version 2.0.0:
+
+* Add windows-pr gem dependency to get ruby_bin_path correctly
+* Add command sender feature to use pipe to control workers for Windows
+* Delete MultiprocessLogDevice implementation to use Ruby's one always
+* Refactor modules and methods to clean internal file dependency
+* Add example script to run servers
+* Fix required Ruby version to 2.1 or later
+
 2016-05-19 version 1.6.4:
 
 * Refactor to delete some warnings

--- a/lib/serverengine/version.rb
+++ b/lib/serverengine/version.rb
@@ -1,3 +1,3 @@
 module ServerEngine
-  VERSION = "1.6.4"
+  VERSION = "2.0.0"
 end

--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.has_rdoc = false
 
-  gem.required_ruby_version = ">= 1.9.3"
+  gem.required_ruby_version = ">= 2.1.0"
 
   gem.add_dependency "sigdump", ["~> 0.2.2"]
 


### PR DESCRIPTION
This is the proposal change for releasing v2.0.0.
This change includes:
* Ruby version dependency (updated to 2.1): 2.0 or earlier are not maintained now
* Major version update

Recent changes includes changes of modules/classes, and some others. These changes are not breaking changes for users, but may be problematic changes if users' code touches internal of ServerEngine. So this update should be major update.
