### PR TITLE
build gems for windows platform

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,6 @@ namespace :build do
         Rake::Task["build"].execute
       end
     end
-	end
+  end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,19 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 task :default => [:spec, :build]
+
+# 1. update Changelog and lib/serverengine/version.rb
+# 2. bundle && bundle exec rake build:all
+# 3. release 3 packages built on pkg/ directory
+namespace :build do
+  desc 'Build gems for all platforms'
+  task :all do
+    Bundler.with_clean_env do
+      %w[ruby x86-mingw32 x64-mingw32].each do |name|
+        ENV['GEM_BUILD_FAKE_PLATFORM'] = name
+        Rake::Task["build"].execute
+      end
+    end
+	end
+end
+

--- a/serverengine.gemspec
+++ b/serverengine.gemspec
@@ -24,7 +24,14 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", [">= 0.9.2"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]
 
-  if /mswin|mingw/ =~ RUBY_PLATFORM
+  gem.add_development_dependency 'rake-compiler-dock', ['~> 0.5.0']
+  gem.add_development_dependency 'rake-compiler', ['~> 0.9.4']
+
+  # build gem for a certain platform. see also Rakefile
+  fake_platform = ENV['GEM_BUILD_FAKE_PLATFORM'].to_s
+  gem.platform = fake_platform unless fake_platform.empty?
+  if /mswin|mingw/ =~ fake_platform || (/mswin|mingw/ =~ RUBY_PLATFORM && fake_platform.empty?)
+    # windows dependencies
     gem.add_runtime_dependency("windows-pr", ["~> 1.2.5"])
   end
 end


### PR DESCRIPTION
gemspec contains a runtime dependency for Windows platform. However,
because gemspec is evaluated on a local machine, built gems will
contain pre-evaluated yaml file. Therefore, either of following happens:

* if the gem is built on a non-windows machine, Windows users can't
  run serverengine correctly due to lack of windows-specific dependencies
* if the gem is built on Windows machine, non-windows users can't install
  the released gem due to windows-specific dependencies

`build:all` task fakes `gem.platform` only so that it builds 3 versions
of gems (universal, 32bit-windows, 64-bit windows).

This is doable without cross compiler because serverengine itself
doesn't have native extensions.
