### PR TITLE
A new feature to specify exit codes not to restart worker processes, and stop server

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ se = ServerEngine.create(nil, MyWorker, {
 se.run
 ```
 
+This auto restart reature will be suppressed for workers which exits with exit code specified by `unrecoverable_exit_codes`. At this case, whole process will exit without error (exit code 0).
 
 ## Live restart
 
@@ -489,6 +490,7 @@ Available methods are different depending on `worker_type`. ServerEngine support
   - **worker_immediate_kill_interval** sets the first interval of QUIT signals in seconds (default: 10) [dynamic reloadable]
   - **worker_immediate_kill_interval_increment** sets increment of QUIT signal interval in seconds (default: 10) [dynamic reloadable]
   - **worker_immediate_kill_timeout** sets promotion timeout from QUIT to KILL signal in seconds. -1 means no timeout (default: 600) [dynamic reloadable]
+  - **unrecoverable_exit_codes** handles worker processes, which exits with code included in this value, as unrecoverable (not to restart) (default: [])
 - Multiprocess spawn server: available only when `worker_type` is "spawn"
   - all parameters of multiprocess server excepting worker_process_name
   - **worker_reload_signal** sets the signal to notice configuration reload to a spawned process. Set nil to disable (default: nil)

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Available methods are different depending on `worker_type`. ServerEngine support
   - **worker_immediate_kill_interval_increment** sets increment of QUIT signal interval in seconds (default: 10) [dynamic reloadable]
   - **worker_immediate_kill_timeout** sets promotion timeout from QUIT to KILL signal in seconds. -1 means no timeout (default: 600) [dynamic reloadable]
   - **unrecoverable_exit_codes** handles worker processes, which exits with code included in this value, as unrecoverable (not to restart) (default: [])
+  - **stop_immediately_at_unrecoverable_exit** stops server immediately if a worker exits with unrecoverable exit status (default: false)
 - Multiprocess spawn server: available only when `worker_type` is "spawn"
   - all parameters of multiprocess server excepting worker_process_name
   - **worker_reload_signal** sets the signal to notice configuration reload to a spawned process. Set nil to disable (default: nil)

--- a/examples/server.rb
+++ b/examples/server.rb
@@ -7,6 +7,8 @@ require 'optparse'
 # bundle exec ruby example/server.rb [-t TYPE] [-w NUM]
 # available type of workers are: embedded(default), process, thread, spawn
 
+foreground = false
+supervisor = false
 worker_type = nil
 workers = 4
 exit_with_code = nil
@@ -16,6 +18,8 @@ stop_immediately_at_exit = false
 unrecoverable_exit_codes = []
 
 opt = OptionParser.new
+opt.on('-f'){ foreground = true }
+opt.on('-x'){ supervisor = true }
 opt.on('-t TYPE'){|v| worker_type = v }
 opt.on('-w NUM'){|v| workers = v.to_i }
 opt.on('-e NUM'){|v| exit_with_code = v.to_i }
@@ -110,8 +114,9 @@ module MySpawnWorker
 end
 
 opts = {
-  daemonize: true,
+  daemonize: !foreground,
   daemon_process_name: 'mydaemon',
+  supervisor: supervisor,
   log: 'myserver.log',
   pid_path: 'myserver.pid',
   worker_type: worker_type,

--- a/examples/spawn_worker_script.rb
+++ b/examples/spawn_worker_script.rb
@@ -10,9 +10,11 @@ begin
   socket_manager = ServerEngine::SocketManager::Client.new(ENV['SERVER_ENGINE_SOCKET_MANAGER_PATH'])
   exit_with_code = ENV.key?('EXIT_WITH_CODE') ? ENV['EXIT_WITH_CODE'].to_i : nil
   exit_at_seconds = ENV.key?('EXIT_AT_SECONDS') ? ENV['EXIT_AT_SECONDS'].to_i : nil
+  exit_at_random = ENV.key?('EXIT_AT_RANDOM')
   stop_at = if exit_with_code
-              logger.info "Stop #{exit_at_seconds} seconds later with code #{exit_with_code}."
-              Time.now + exit_at_seconds
+              stop_seconds = exit_at_random ? rand(exit_at_seconds) : exit_at_seconds
+              logger.info "Stop #{stop_seconds} seconds later with code #{exit_with_code}."
+              Time.now + stop_seconds
             else
               nil
             end

--- a/lib/serverengine/daemon.rb
+++ b/lib/serverengine/daemon.rb
@@ -116,7 +116,11 @@ module ServerEngine
         @pid = Process.pid
         s = create_server(create_logger)
         s.install_signal_handlers
-        s.main
+        begin
+          s.main
+        rescue SystemExit => e
+          return e.status
+        end
         return 0
       end
     end
@@ -165,7 +169,11 @@ module ServerEngine
             wpipe.write "\n"
             wpipe.close
 
-            s.main
+            begin
+              s.main
+            rescue SystemExit => e
+              exit e.status
+            end
           end
 
           exit 0

--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -97,10 +97,11 @@ module ServerEngine
     end
 
     class WorkerMonitor
-      def initialize(worker, wid, pmon)
+      def initialize(worker, wid, pmon, reload_signal = Signals::RELOAD)
         @worker = worker
         @wid = wid
         @pmon = pmon
+        @reload_signal = reload_signal
       end
 
       def send_stop(stop_graceful)
@@ -114,7 +115,7 @@ module ServerEngine
       end
 
       def send_reload
-        @pmon.send_signal(Signals::RELOAD) if @pmon
+        @pmon.send_signal(@reload_signal) if @pmon
         nil
       end
 

--- a/lib/serverengine/multi_process_server.rb
+++ b/lib/serverengine/multi_process_server.rb
@@ -105,7 +105,10 @@ module ServerEngine
         @reload_signal = reload_signal
         @unrecoverable_exit_codes = unrecoverable_exit_codes
         @unrecoverable_exit = false
+        @exitstatus = nil
       end
+
+      attr_reader :exitstatus
 
       def send_stop(stop_graceful)
         @stop = true
@@ -134,6 +137,7 @@ module ServerEngine
           @worker.logger.info "Worker #{@wid} finished#{@stop ? '' : ' unexpectedly'} with #{ServerEngine.format_join_status(stat)}"
           if stat.is_a?(Process::Status) && stat.exited? && @unrecoverable_exit_codes.include?(stat.exitstatus)
             @unrecoverable_exit = true
+            @exitstatus = stat.exitstatus
           end
           @pmon = nil
           return false

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -42,6 +42,7 @@ module ServerEngine
       super(worker_module, load_config_proc, &block)
 
       @reload_signal = @config[:worker_reload_signal]
+      @unrecoverable_exit_codes = @config.fetch(:unrecoverable_exit_codes, [])
       @pm.command_sender = @command_sender
     end
 
@@ -83,7 +84,7 @@ module ServerEngine
         w.after_start
       end
 
-      return MultiProcessServer::WorkerMonitor.new(w, wid, pmon, @reload_signal)
+      return MultiProcessServer::WorkerMonitor.new(w, wid, pmon, @reload_signal, unrecoverable_exit_codes: @unrecoverable_exit_codes)
     end
 
     def wait_tick

--- a/lib/serverengine/multi_spawn_server.rb
+++ b/lib/serverengine/multi_spawn_server.rb
@@ -83,25 +83,11 @@ module ServerEngine
         w.after_start
       end
 
-      return WorkerMonitor.new(w, wid, pmon, @reload_signal)
+      return MultiProcessServer::WorkerMonitor.new(w, wid, pmon, @reload_signal)
     end
 
     def wait_tick
       @pm.tick(0.5)
-    end
-
-    class WorkerMonitor < MultiProcessServer::WorkerMonitor
-      def initialize(worker, wid, pmon, reload_signal)
-        super(worker, wid, pmon)
-        @reload_signal = reload_signal
-      end
-
-      def send_reload
-        if @reload_signal
-          @pmon.send_signal(@reload_signal) if @pmon
-        end
-        nil
-      end
     end
   end
 

--- a/lib/serverengine/multi_thread_server.rb
+++ b/lib/serverengine/multi_thread_server.rb
@@ -70,6 +70,10 @@ module ServerEngine
       def alive?
         @thread.alive?
       end
+
+      def recoverable?
+        true
+      end
     end
   end
 

--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -103,13 +103,14 @@ module ServerEngine
           # alive
           num_alive += 1
 
-        elsif m && !m.recoverable?
+        elsif m && m.respond_to?(:recoverable?) && !m.recoverable?
           # exited, with unrecoverable exit code
           if @stop_immediately_at_unrecoverable_exit
             stop(true) # graceful stop for workers
             # @stop is set by Server#stop
           end
           # server will stop when all workers exited in this state
+          @stop_status ||= m.exitstatus if m.exitstatus
 
         elsif wid < @num_workers
           # scale up or reboot

--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -25,6 +25,8 @@ module ServerEngine
       @last_start_worker_time = 0
 
       super(worker_module, load_config_proc, &block)
+
+      @stop_immediately_at_unrecoverable_exit = @config.fetch(:stop_immediately_at_unrecoverable_exit, false)
     end
 
     def stop(stop_graceful)
@@ -103,7 +105,11 @@ module ServerEngine
 
         elsif m && !m.recoverable?
           # exited, with unrecoverable exit code
-          # nothing to do: server will stop when all workers exited in this state
+          if @stop_immediately_at_unrecoverable_exit
+            stop(true) # graceful stop for workers
+            # @stop is set by Server#stop
+          end
+          # server will stop when all workers exited in this state
 
         elsif wid < @num_workers
           # scale up or reboot

--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -110,7 +110,8 @@ module ServerEngine
             # @stop is set by Server#stop
           end
           # server will stop when all workers exited in this state
-          @stop_status ||= m.exitstatus if m.exitstatus
+          # the last status will be used for server/supervisor/daemon
+          @stop_status = m.exitstatus if m.exitstatus
 
         elsif wid < @num_workers
           # scale up or reboot

--- a/lib/serverengine/multi_worker_server.rb
+++ b/lib/serverengine/multi_worker_server.rb
@@ -101,6 +101,10 @@ module ServerEngine
           # alive
           num_alive += 1
 
+        elsif m && !m.recoverable?
+          # exited, with unrecoverable exit code
+          # nothing to do: server will stop when all workers exited in this state
+
         elsif wid < @num_workers
           # scale up or reboot
           unless @stop

--- a/lib/serverengine/server.rb
+++ b/lib/serverengine/server.rb
@@ -28,6 +28,7 @@ module ServerEngine
       @worker_module = worker_module
 
       @stop = false
+      @stop_status = nil
 
       super(load_config_proc, &block)
 
@@ -122,6 +123,9 @@ module ServerEngine
         run
       ensure
         after_run
+      end
+      if @stop_status
+        raise SystemExit.new(@stop_status)
       end
     end
 

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -98,4 +98,71 @@ describe ServerEngine::Daemon do
       dm.stop(true) rescue nil
     end
   end
+
+  it 'exits with status 0 when it was stopped normally' do
+    dm = Daemon.new(
+      TestServer,
+      TestWorker,
+      daemonize: false,
+      supervisor: false,
+      pid_path: "tmp/pid",
+      log_stdout: false,
+      log_stderr: false,
+      unrecoverable_exit_codes: [3,4,5],
+    )
+    exit_code = nil
+    t = Thread.new { exit_code = dm.main }
+    sleep 0.1 until dm.instance_eval{ @pid }
+    dm.stop(true)
+
+    t.join
+
+    exit_code.should == 0
+  end
+
+  it 'exits with status of workers if worker exits with status specified in unrecoverable_exit_codes, without supervisor' do
+    pending "worker type process(fork) cannot be used in Windows" if ServerEngine.windows?
+
+    dm = Daemon.new(
+      TestServer,
+      TestExitWorker,
+      daemonize: false,
+      supervisor: false,
+      worker_type: 'process',
+      pid_path: "tmp/pid",
+      log_stdout: false,
+      log_stderr: false,
+      unrecoverable_exit_codes: [3,4,5],
+    )
+    exit_code = nil
+    t = Thread.new { exit_code = dm.main }
+    sleep 0.1 until dm.instance_eval{ @pid }
+
+    t.join
+
+    exit_code.should == 5
+  end
+
+  it 'exits with status of workers if worker exits with status specified in unrecoverable_exit_codes, with supervisor' do
+    pending "worker type process(fork) cannot be used in Windows" if ServerEngine.windows?
+
+    dm = Daemon.new(
+      TestServer,
+      TestExitWorker,
+      daemonize: false,
+      supervisor: true,
+      worker_type: 'process',
+      pid_path: "tmp/pid",
+      log_stdout: false,
+      log_stderr: false,
+      unrecoverable_exit_codes: [3,4,5],
+    )
+    exit_code = nil
+    t = Thread.new { exit_code = dm.main }
+    sleep 0.1 until dm.instance_eval{ @pid }
+
+    t.join
+
+    exit_code.should == 5
+  end
 end

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -100,14 +100,13 @@ describe ServerEngine::Daemon do
   end
 
   it 'exits with status 0 when it was stopped normally' do
+    pending "worker type process(fork) cannot be used in Windows" if ServerEngine.windows?
     dm = Daemon.new(
       TestServer,
       TestWorker,
       daemonize: false,
       supervisor: false,
       pid_path: "tmp/pid",
-      windows_daemon_cmdline: windows_daemon_cmdline,
-      command_sender: "pipe",
       log_stdout: false,
       log_stderr: false,
       unrecoverable_exit_codes: [3,4,5],

--- a/spec/daemon_spec.rb
+++ b/spec/daemon_spec.rb
@@ -106,6 +106,8 @@ describe ServerEngine::Daemon do
       daemonize: false,
       supervisor: false,
       pid_path: "tmp/pid",
+      windows_daemon_cmdline: windows_daemon_cmdline,
+      command_sender: "pipe",
       log_stdout: false,
       log_stderr: false,
       unrecoverable_exit_codes: [3,4,5],

--- a/spec/multi_process_server_spec.rb
+++ b/spec/multi_process_server_spec.rb
@@ -62,6 +62,7 @@
 
     it 'raises SystemExit when all workers exit with specified code by unrecoverable_exit_codes' do
       pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
+      pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
       config = {workers: 4, log_stdout: false, log_stderr: false, unrecoverable_exit_codes: [3, 4, 5]}
 
@@ -85,6 +86,7 @@
 
     it 'raises SystemExit immediately when a worker exits if stop_immediately_at_unrecoverable_exit specified' do
       pending "unrecoverable_exit_codes supported only for multi process workers" if impl_class == ServerEngine::MultiThreadServer
+      pending "Windows environment does not support fork" if ServerEngine.windows? && impl_class == ServerEngine::MultiProcessServer
 
       config = {workers: 4, log_stdout: false, log_stderr: false, unrecoverable_exit_codes: [3, 4, 5], stop_immediately_at_unrecoverable_exit: true}
 


### PR DESCRIPTION
This is a proposal to change NOT to restart worker processes which exits with specified exit code.
This feature is needed to avoid cases like:
* worker processes fails to startup with unrecoverable runtime errors, like configuration errors, "plugin not found" or others
* worker processes exits normally, for the cases like "this process will stop at the end of this year".

You can check the behavior of this feature on actual processes with the command line below:
```
# process(fork), worker process exits with code 5 (5 seconds later in default)
# server handles 0 and 5 as unrecoverable code
bundle exec ruby examples/server.rb -t process -w 3 -e 5 -u 0 -u 5

# spawn, worker process exits with code 0 (5 seconds later in default)
# server handles 0 and 5 as unrecoverable code
bundle exec ruby examples/server.rb -t spawn -w 3 -e 0 -s 10 -u 0 -u 5
```
Logs for latter case:
<details>
```
I, [2016-08-25T15:30:40.314477 #21627]  INFO -- : Server stopped.
I, [2016-08-25T15:59:08.152610 #26780]  INFO -- : Starting to run Worker.
I, [2016-08-25T15:59:08.163854 #26780]  INFO -- : Stop 10 seconds later with code 0.
I, [2016-08-25T15:59:08.165475 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:08.196556 #26781]  INFO -- : Starting to run Worker.
I, [2016-08-25T15:59:08.196635 #26781]  INFO -- : Stop 10 seconds later with code 0.
I, [2016-08-25T15:59:08.197315 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:08.208610 #26782]  INFO -- : Starting to run Worker.
I, [2016-08-25T15:59:08.208725 #26782]  INFO -- : Stop 10 seconds later with code 0.
I, [2016-08-25T15:59:08.209260 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:09.166832 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:09.201788 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:09.209471 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:10.169705 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:10.204142 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:10.209852 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:11.170360 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:11.206968 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:11.210619 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:12.172495 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:12.210954 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:12.213858 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:13.177898 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:13.211498 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:13.216946 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:14.179521 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:14.213264 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:14.219620 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:15.183492 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:15.218210 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:15.220865 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:16.187969 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:16.222704 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:16.223611 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:17.189113 #26780]  INFO -- : Awesome work!
I, [2016-08-25T15:59:17.223782 #26781]  INFO -- : Awesome work!
I, [2016-08-25T15:59:17.223918 #26782]  INFO -- : Awesome work!
I, [2016-08-25T15:59:18.192163 #26780]  INFO -- : Exitting with code 0
I, [2016-08-25T15:59:18.195514 #26779]  INFO -- : Worker 0 finished unexpectedly with status 0
I, [2016-08-25T15:59:18.226712 #26782]  INFO -- : Exitting with code 0
I, [2016-08-25T15:59:18.226712 #26781]  INFO -- : Exitting with code 0
I, [2016-08-25T15:59:18.231249 #26779]  INFO -- : Worker 1 finished unexpectedly with status 0
I, [2016-08-25T15:59:18.231476 #26779]  INFO -- : Worker 2 finished unexpectedly with status 0
I, [2016-08-25T15:59:18.231625 #26779]  INFO -- : Server stopped.
```
</details>