### PR TITLE
add disable log rotate document

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,8 +498,8 @@ Available methods are different depending on `worker_type`. ServerEngine support
 - Logger
   - **log** sets path to log file. Set "-" for STDOUT (default: STDERR) [dynamic reloadable]
   - **log_level** log level: trace, debug, info, warn, error or fatal. (default: debug) [dynamic reloadable]
-  - **log_rotate_age** generations to keep rotated log files (default: 5)
-  - **log_rotate_size** sets the size to rotate log files (default: 1048576)
+  - **log_rotate_age** generations to keep rotated log files (default: 5), 0 will disable log rotate.
+  - **log_rotate_size** sets the size to rotate log files (default: 1048576), when `log_rotate_age` is 0, the `log_rotate_size` value will be ignored.
   - **log_stdout** hooks STDOUT to log file (default: true)
   - **log_stderr** hooks STDERR to log file (default: true)
   - **logger_class** class of the logger instance (default: ServerEngine::DaemonLogger)


### PR DESCRIPTION
when `log_rotate_age` is 0, will disable log rotate. [details](https://github.com/ruby/ruby/blob/95ed081663af63b688f5094d2c454adb4e64f63f/lib/logger.rb#L621)