### PR TITLE
fix for issue #74, set gid before uid

### DIFF
--- a/lib/serverengine/privilege.rb
+++ b/lib/serverengine/privilege.rb
@@ -36,6 +36,11 @@ module ServerEngine
     end
 
     def self.change(user, group)
+      if group
+        etc_group = get_etc_group(group)
+        Process::GID.change_privilege(etc_group.gid)
+      end
+
       if user
         etc_pw = get_etc_passwd(user)
         user_groups = [etc_pw.gid]
@@ -44,11 +49,6 @@ module ServerEngine
 
         Process.groups = Process.groups | user_groups
         Process::UID.change_privilege(etc_pw.uid)
-      end
-
-      if group
-        etc_group = get_etc_group(group)
-        Process::GID.change_privilege(etc_group.gid)
       end
 
       nil


### PR DESCRIPTION
In response to #74  ...

This switches the order of setting GID with UID.

If the UID is set first, the process doesn't have permissions to modify GID.

This would be the case when run via `sudo /usr/local/bin/fluentd -d -u fluentd -g fluentd ...`.